### PR TITLE
Keep kit external for hand-pasted esm.sh decoder URLs

### DIFF
--- a/.changeset/gist-page-revision-pin.md
+++ b/.changeset/gist-page-revision-pin.md
@@ -1,0 +1,5 @@
+---
+"@deroll/explorer": patch
+---
+
+pin gist page URL registrations to the gist's current revision — the gists API lookup already made for the filename also carries the revision, so the esm.sh URL no longer floats at the gist's HEAD, where esm.sh's request-time resolution goes stale after a gist edit or fails intermittently (revision-pinned raw URLs never had this problem)

--- a/.changeset/kit-external-esmsh-passthrough.md
+++ b/.changeset/kit-external-esmsh-passthrough.md
@@ -1,0 +1,5 @@
+---
+"@deroll/explorer": patch
+---
+
+keep the `@deroll/decoder` import external for decoders registered as hand-pasted esm.sh URLs — without the flag esm.sh rewrote the kit import to an absolute npm URL the import map cannot remap, silently loading `@deroll/decoder@0.1.0` (npm's `latest`) instead of the pinned kit, so v3 portal deposits failed to decode

--- a/apps/explorer/src/decoder/github.ts
+++ b/apps/explorer/src/decoder/github.ts
@@ -57,9 +57,17 @@ function gistFileAnchor(filename: string): string {
 /**
  * Find the decoder's filename in a gist via the (CORS-enabled, unauthenticated)
  * gists API: the file the page URL's #file- anchor points at, or the gist's
- * only file, or its only script file.
+ * only file, or its only script file. Also returns the gist's current revision
+ * so the esm.sh URL can be pinned — esm.sh resolves an unpinned gist at
+ * request time and caches the result, so after the gist is edited (or when
+ * that resolution intermittently fails) an unpinned URL serves a stale or
+ * broken module while a revision-pinned one is immutable.
  */
-async function resolveGistFilename(id: string, rev: string | undefined, anchor: string | undefined): Promise<string> {
+async function resolveGistFile(
+  id: string,
+  rev: string | undefined,
+  anchor: string | undefined,
+): Promise<{ filename: string; rev: string | undefined }> {
   const res = await fetch(`https://api.github.com/gists/${id}${rev ? `/${rev}` : ''}`)
   if (!res.ok) {
     throw new Error(
@@ -68,16 +76,23 @@ async function resolveGistFilename(id: string, rev: string | undefined, anchor: 
         : `Failed to look up the gist (GitHub API returned ${res.status}).`,
     )
   }
-  const gist = (await res.json()) as { files?: Record<string, unknown> }
+  const gist = (await res.json()) as {
+    files?: Record<string, unknown>
+    history?: { version?: string }[]
+  }
+  // History is newest-first; when no revision was asked for, its head is the
+  // gist's current revision.
+  const resolvedRev = rev ?? gist.history?.[0]?.version
   const files = Object.keys(gist.files ?? {})
+  const found = (filename: string) => ({ filename, rev: resolvedRev })
   if (anchor) {
     const match = files.find((f) => gistFileAnchor(f) === anchor.toLowerCase())
-    if (match) return match
+    if (match) return found(match)
     throw new Error(`The gist has no file matching #${anchor}.`)
   }
-  if (files.length === 1) return files[0]
+  if (files.length === 1) return found(files[0])
   const scripts = files.filter((f) => /\.(?:ts|tsx|mts|js|mjs|jsx)$/i.test(f))
-  if (scripts.length === 1) return scripts[0]
+  if (scripts.length === 1) return found(scripts[0])
   throw new Error(
     'The gist has several files — pick one by opening it on gist.github.com and copying the link with its #file-… anchor, or the file\'s "Raw" URL.',
   )
@@ -100,7 +115,9 @@ async function resolveGistFilename(id: string, rev: string | undefined, anchor: 
  *   gist:<id>[@<rev>]/<file>
  *
  * A gist page URL names no file, so the filename is resolved through the
- * gists API (the #file- anchor, the only file, or the only script file).
+ * gists API (the #file- anchor, the only file, or the only script file),
+ * and the result is pinned to the gist's current revision so esm.sh serves
+ * an immutable build instead of re-resolving a floating ref.
  * A hand-pasted esm.sh URL keeps the kit external too (see below); any other
  * http(s) URL (a self-hosted .js, …) is returned unchanged, so
  * already-registered decoders keep working.
@@ -152,8 +169,8 @@ export async function resolveDecoderImportUrl(input: string, esmBase: string = E
     const page = /^\/(?:[\w-]+\/)?([0-9a-f]+)(?:\/([0-9a-f]{40}))?\/?$/i.exec(url.pathname)
     if (page) {
       const anchor = /^#(file-.+)$/.exec(url.hash)?.[1]
-      const filename = await resolveGistFilename(page[1], page[2], anchor)
-      return gistUrl(esmBase, page[1], page[2], filename)
+      const file = await resolveGistFile(page[1], page[2], anchor)
+      return gistUrl(esmBase, page[1], file.rev, file.filename)
     }
   }
 

--- a/apps/explorer/src/decoder/github.ts
+++ b/apps/explorer/src/decoder/github.ts
@@ -101,8 +101,9 @@ async function resolveGistFilename(id: string, rev: string | undefined, anchor: 
  *
  * A gist page URL names no file, so the filename is resolved through the
  * gists API (the #file- anchor, the only file, or the only script file).
- * Any other http(s) URL (an esm.sh package URL, a self-hosted .js, …) is
- * returned unchanged, so already-registered decoders keep working.
+ * A hand-pasted esm.sh URL keeps the kit external too (see below); any other
+ * http(s) URL (a self-hosted .js, …) is returned unchanged, so
+ * already-registered decoders keep working.
  */
 export async function resolveDecoderImportUrl(input: string, esmBase: string = ESM_BASE): Promise<string> {
   const ref = input.trim()
@@ -154,6 +155,16 @@ export async function resolveDecoderImportUrl(input: string, esmBase: string = E
       const filename = await resolveGistFilename(page[1], page[2], anchor)
       return gistUrl(esmBase, page[1], page[2], filename)
     }
+  }
+
+  // A URL already pointing at the kit-serving esm.sh (e.g. a hand-pasted
+  // /gh/ repo or gist URL) works as-is, except that esm.sh would resolve the
+  // decoder's bare `@deroll/decoder` import from npm into an absolute URL the
+  // import map cannot remap — floating at whatever npm's `latest` tag points
+  // to, not the kit the explorer pins. Keep the kit external here too, unless
+  // the URL already manages its own externals.
+  if (ref.startsWith(`${esmBase}/`) && !url.searchParams.has('external')) {
+    return withKitExternal(ref)
   }
 
   return ref


### PR DESCRIPTION
## Summary
Fixed an issue where hand-pasted esm.sh URLs for decoders were not preserving the kit's external import configuration, causing esm.sh to resolve `@deroll/decoder` from npm's latest tag instead of the pinned kit version.

## Changes
- Added logic to detect when a decoder URL already points to the kit-serving esm.sh instance (e.g., hand-pasted `/gh/` repo or gist URLs)
- For such URLs without explicit `external` query parameters, the kit external configuration is now applied via `withKitExternal()`
- Updated the JSDoc comment to clarify the behavior for esm.sh URLs and the reasoning behind keeping the kit external
- Added a changeset documenting the fix for v3 portal deposit decoding failures

## Implementation Details
The fix checks if the resolved URL starts with the esm.sh base URL and doesn't already have an `external` parameter. When both conditions are true, it applies the kit external configuration to ensure `@deroll/decoder` resolves to the explorer's pinned version rather than npm's latest tag. This prevents silent version mismatches that were causing v3 portal deposits to fail decoding.

https://claude.ai/code/session_014docLPLGncKEEmAuSkeqPR