### PR TITLE
fix(explorer): truncate addresses in Contracts and Withdrawal config sections

### DIFF
--- a/apps/explorer/src/pages/AppOverview.tsx
+++ b/apps/explorer/src/pages/AppOverview.tsx
@@ -44,9 +44,9 @@ export function AppOverview() {
         <Section title="Contracts">
           <KV
             rows={[
-              ['Application', <Hex value={app.iapplication_address} full />],
-              ['Consensus', <Hex value={app.iconsensus_address} full />],
-              ['Input box', <Hex value={app.iinputbox_address} full />],
+              ['Application', <Hex value={app.iapplication_address} />],
+              ['Consensus', <Hex value={app.iconsensus_address} />],
+              ['Input box', <Hex value={app.iinputbox_address} />],
               ['Template hash', <Hex value={app.template_hash} />],
               ['Data availability', <Hex value={app.data_availability} />],
               ['Input box deployed at block', formatUint(app.iinputbox_block)],
@@ -72,10 +72,10 @@ export function AppOverview() {
           {app.withdrawal_config ? (
             <KV
               rows={[
-                ['Guardian', <Hex value={app.withdrawal_config.guardian} full />],
+                ['Guardian', <Hex value={app.withdrawal_config.guardian} />],
                 [
                   'Output builder',
-                  <Hex value={app.withdrawal_config.withdrawal_output_builder} full />,
+                  <Hex value={app.withdrawal_config.withdrawal_output_builder} />,
                 ],
                 [
                   'Accounts drive start index',


### PR DESCRIPTION
## Summary

On the application overview (home) page of the explorer, the addresses in the **Contracts** and **Withdrawal config** sections were rendered full-length (`full` prop on the `Hex` component), which overflowed and broke the two-column layout.

This removes the `full` prop from those five rows (Application, Consensus, Input box, Guardian, Output builder) so they use the `Hex` component's default middle truncation (`0x12345678…abcdef`). Nothing is lost: the full address is still shown in the hover tooltip and the copy button copies the complete value. This also makes them consistent with the Template hash and Data availability rows, which were already truncated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B2t6oyr5zPy7xKzei1UPD