### PR TITLE
fix(explorer): truncate tx hashes and proof values in foreclosure section

### DIFF
--- a/apps/explorer/src/pages/AppOverview.tsx
+++ b/apps/explorer/src/pages/AppOverview.tsx
@@ -103,7 +103,7 @@ export function AppOverview() {
             <KV
               rows={[
                 ['Foreclosed at block', formatUint(app.foreclose_block)],
-                ['Foreclose transaction', <TxHash value={app.foreclose_transaction} full />],
+                ['Foreclose transaction', <TxHash value={app.foreclose_transaction} />],
                 [
                   'Accounts drive proved at block',
                   isZeroHex(app.accounts_drive_proved_block)
@@ -112,9 +112,9 @@ export function AppOverview() {
                 ],
                 [
                   'Accounts drive proved transaction',
-                  <TxHash value={app.accounts_drive_proved_transaction} full />,
+                  <TxHash value={app.accounts_drive_proved_transaction} />,
                 ],
-                ['Accounts drive merkle root', <Hex value={app.accounts_drive_merkle_root} full />],
+                ['Accounts drive merkle root', <Hex value={app.accounts_drive_merkle_root} />],
               ]}
             />
           )}


### PR DESCRIPTION
The Foreclosure card in the application overview rendered the foreclose transaction, accounts drive proved transaction, and accounts drive merkle root at full length (`full` prop), overflowing the two-column grid and breaking the layout.

This drops the `full` prop on those three rows so they use the `Hex` component's default middle truncation (`0x12345678…abcdef`). Nothing is lost: the click-to-copy button still copies the complete value, and transaction hashes keep their block-explorer link.

Other `full` usages (EpochPage, MatchPage, etc.) are on single-column detail pages where full-width hashes fit, and are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wr5KoHUb2GB4WrVfytFA1W