### PR TITLE
Pin npm to v11 for trusted publishing compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,9 +148,12 @@ jobs:
                   registry-url: https://registry.npmjs.org
 
             # Trusted publishing (OIDC) requires npm >= 11.5.1; node 24 bundles
-            # npm 10. `changeset publish` shells out to this npm.
+            # npm 10. `changeset publish` shells out to this npm. Pinned to 11:
+            # the npm@12.0.0 tarball ships libnpmpublish without a resolvable
+            # sigstore dependency, so provenance publishing fails with
+            # MODULE_NOT_FOUND "Cannot find module 'sigstore'".
             - name: Update npm for trusted publishing
-              run: npm install -g npm@latest
+              run: npm install -g npm@11
 
             - name: Install Dependencies
               run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
Updated the release workflow to pin npm to version 11 instead of using the latest version, due to a critical issue with npm v12.0.0's provenance publishing support.

## Key Changes
- Changed npm installation from `npm@latest` to `npm@11` in the release workflow
- Added detailed explanation of the issue: npm v12.0.0's tarball ships `libnpmpublish` without a resolvable `sigstore` dependency, causing MODULE_NOT_FOUND errors during provenance publishing

## Implementation Details
The change ensures that the `changeset publish` command can successfully perform trusted publishing (OIDC) with proper provenance support. While npm >= 11.5.1 is required for OIDC support, npm v12.0.0 introduces a regression that breaks the sigstore dependency resolution needed for provenance publishing. Pinning to v11 maintains the required OIDC functionality while avoiding this regression.

https://claude.ai/code/session_01B5Ub4kMionxRN2S9asjxVs