### PR TITLE
Upgrade Cartesi Machine binding from 0.19.0 to 0.20.0

### DIFF
--- a/.changeset/cm-emulator-0-20.md
+++ b/.changeset/cm-emulator-0-20.md
@@ -1,0 +1,14 @@
+---
+"@deroll/cm": minor
+---
+
+Upgrade the binding from machine-emulator 0.19.0 to 0.20.0. This is a breaking change that follows the upstream C API:
+
+- Machine config: `image_filename`/`shared` replaced by the `backing_store` object (`data_filename`, `dht_filename`, `dpt_filename`, `shared`, `create`, `truncate`); processor registers nested under `processor.registers`; `tlb`, `clint`, `plic` and `htif` sections removed; new `pmas` and `hash_tree` sections.
+- Runtime config: `htif.no_console_putchar` replaced by the `console` config with full I/O redirection; `concurrency.update_merkle_tree` renamed to `update_hash_tree`; `skip_root_hash_check`/`skip_root_hash_store` removed; new `no_reserve`.
+- `create()` accepts an optional `dir` for on-disk machines; `load()` and `store()` accept an optional `SharingMode` (`None`, `Config`, `All`).
+- `getMemoryRanges()` renamed to `getAddressRanges()`; `replaceMemoryRange()` now takes a `MemoryRangeConfig` object; `getProof()` accepts an optional `log2RootSize`.
+- `verifyMerkleTree()` renamed to `verifyHashTree()`; `verifyDirtyPageMaps()` removed in favor of `getHashTreeStats()`.
+- `Constant.TreeLog2*` renamed to `Constant.HashTreeLog2*`; `PmaConstant` renamed to `ArConstant` with new shadow/PMAs entries.
+- New: `getVersion()`, `writeWord()`, `getNodeHash()`, `cloneStored()`, `removeStored()`, `readConsoleOutput()`, `writeConsoleInput()`, `collectMcycleRootHashes()`, `collectUarchCycleRootHashes()`, `getHash()`, `getConcatHash()`, `MAX_UARCH_CYCLE`, `BreakReason.ConsoleOutput`/`ConsoleInput`, `UarchBreakReason.CycleOverflow`, `SharingMode` and `HashFunction` enums.
+- Fixed `MAX_MCYCLE` to be `UINT64_MAX` (it previously overflowed 64 bits).

--- a/apps/docs/pages/cm/api/cartesi-machine.mdx
+++ b/apps/docs/pages/cm/api/cartesi-machine.mdx
@@ -9,10 +9,12 @@ Descriptions for each method are in the following sections.
 export interface CartesiMachine {
     //// Machine Lifecycle
     isEmpty(): boolean;
-    create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig): void;
-    load(dir: string, runtimeConfig?: MachineRuntimeConfig): void;
+    create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig, dir?: string): void;
+    load(dir: string, runtimeConfig?: MachineRuntimeConfig, sharing?: SharingMode): void;
     cloneEmpty(): CartesiMachine;
-    store(dir: string): void;
+    store(dir: string, sharing?: SharingMode): void;
+    cloneStored(fromDir: string, toDir: string): void;
+    removeStored(dir: string): void;
     destroy(): void;
     
     //// Configuration
@@ -20,16 +22,12 @@ export interface CartesiMachine {
     getInitialConfig(): MachineConfig;
     setRuntimeConfig(runtimeConfig: MachineRuntimeConfig): void;
     getRuntimeConfig(): MachineRuntimeConfig;
-    getMemoryRanges(): MemoryRangeDescription[];
+    getAddressRanges(): AddressRangeDescription[];
 
     //// Memory Operations
-    replaceMemoryRange(
-        start: bigint,
-        length: bigint,
-        shared: boolean,
-        imageFilename?: string,
-    ): void;
+    replaceMemoryRange(rangeConfig: MemoryRangeConfig): void;
     readWord(address: bigint): bigint;
+    writeWord(address: bigint, value: bigint): void;
     readMemory(address: bigint, length: bigint): Buffer;
     writeMemory(address: bigint, data: Buffer): void;
     readVirtualMemory(address: bigint, length: bigint): Buffer;
@@ -41,16 +39,32 @@ export interface CartesiMachine {
     readReg(reg: Reg): bigint;
     writeReg(reg: Reg, value: bigint): void;
 
+    //// Console I/O
+    readConsoleOutput(maxLength?: bigint): Buffer;
+    writeConsoleInput(data: Buffer): bigint;
+
     //// Execution
     run(mcycleEnd?: bigint): BreakReason;
     runUarch(uarchCycleEnd: bigint): UarchBreakReason;
     resetUarch(): void;
+    collectMcycleRootHashes(
+        mcycleEnd: bigint,
+        mcyclePeriod: bigint,
+        mcyclePhase?: bigint,
+        log2BundleMcycleCount?: number,
+        previousBackTree?: unknown,
+    ): McycleRootHashes;
+    collectUarchCycleRootHashes(
+        mcycleEnd: bigint,
+        log2BundleUarchCycleCount?: number,
+    ): UarchCycleRootHashes;
 
-    //// Merkle Tree Operations
+    //// Hash Tree Operations
     getRootHash(): Buffer;
-    getProof(address: bigint, log2Size: number): Proof;
-    verifyMerkleTree(): boolean;
-    verifyDirtyPageMaps(): boolean;
+    getNodeHash(address: bigint, log2Size: number): Buffer;
+    getProof(address: bigint, log2TargetSize: number, log2RootSize?: number): Proof;
+    verifyHashTree(): boolean;
+    getHashTreeStats(clear?: boolean): HashTreeStats;
 
     //// Execution Log
     logStep(mcycleCount: bigint, logFilename: string): BreakReason;
@@ -100,18 +114,18 @@ isEmpty(): boolean;
 
 ## create
 
-Creates a new machine instance from the given configuration and optional runtime configuration. The machine object must be empty.
+Creates a new machine instance from the given configuration and optional runtime configuration. The machine object must be empty. If `dir` is provided, the machine is created with on-disk state at that directory; otherwise it is created in-memory.
 
 ```ts
-create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig): void;
+create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig, dir?: string): void;
 ```
 
 ## load
 
-Loads a machine instance from a previously stored directory, with optional runtime configuration. The machine object must be empty.
+Loads a machine instance from a previously stored directory, with optional runtime configuration. The machine object must be empty. The `sharing` mode controls whether the machine state is in-memory (`SharingMode.None`, the default), on-disk only for backing stores marked as shared in the configuration (`SharingMode.Config`), or fully on-disk (`SharingMode.All`).
 
 ```ts
-load(dir: string, runtimeConfig?: MachineRuntimeConfig): void;
+load(dir: string, runtimeConfig?: MachineRuntimeConfig, sharing?: SharingMode): void;
 ```
 
 ## cloneEmpty
@@ -124,10 +138,26 @@ cloneEmpty(): CartesiMachine;
 
 ## store
 
-Stores the current machine instance to a directory, serializing its entire state. Will not overwrite an existing directory.
+Stores the current machine instance to a directory, serializing its entire state. Will not overwrite an existing directory. The `sharing` mode specifies how machine changes are reflected in the new store: `SharingMode.All` (the default) stores the current machine state for all backing stores, `SharingMode.Config` stores the current state only for shared backing stores (others are copied from the initial state), and `SharingMode.None` copies backing stores from the initial machine state.
 
 ```ts
-store(dir: string): void;
+store(dir: string, sharing?: SharingMode): void;
+```
+
+## cloneStored
+
+Clones a stored machine from a source directory to a destination directory. Read-only files are copied using hard links, and writable files using reflinks, on filesystems that support them.
+
+```ts
+cloneStored(fromDir: string, toDir: string): void;
+```
+
+## removeStored
+
+Removes all files and the directory of a previously stored machine.
+
+```ts
+removeStored(dir: string): void;
 ```
 
 ## destroy
@@ -170,25 +200,33 @@ Returns the current machine runtime configuration.
 getRuntimeConfig(): MachineRuntimeConfig;
 ```
 
-## getMemoryRanges
+## getAddressRanges
 
-Returns a list of all memory ranges in the machine.
+Returns a list of all address ranges in the machine.
 
 ```ts
-getMemoryRanges(): MemoryRangeDescription[];
+getAddressRanges(): AddressRangeDescription[];
 ```
 
 ## replaceMemoryRange
 
-Replaces a memory range in the machine. The new range must match an existing range's start and length.
+Replaces a memory range in the machine. The new range must match an existing range's start, length, and read-only settings.
 
 ```ts
-replaceMemoryRange(
-    start: bigint,
-    length: bigint,
-    shared: boolean,
-    imageFilename?: string,
-): void;
+replaceMemoryRange(rangeConfig: MemoryRangeConfig): void;
+```
+
+Example:
+
+```ts
+machine.replaceMemoryRange({
+    start: 0x80000000000000,
+    length: 0x100000,
+    backing_store: {
+        data_filename: "drive.bin",
+        shared: false,
+    },
+});
 ```
 
 ## readWord
@@ -197,6 +235,14 @@ Reads a 64-bit word from memory at the given physical address.
 
 ```ts
 readWord(address: bigint): bigint;
+```
+
+## writeWord
+
+Writes a 64-bit word to memory at the given physical address.
+
+```ts
+writeWord(address: bigint, value: bigint): void;
 ```
 
 ## readMemory
@@ -263,6 +309,22 @@ Writes a value to a register.
 writeReg(reg: Reg, value: bigint): void;
 ```
 
+## readConsoleOutput
+
+Reads and consumes data from the console output buffer. Requires the runtime console output destination to be set to `to_buffer`. If `maxLength` is not provided, reads all available data.
+
+```ts
+readConsoleOutput(maxLength?: bigint): Buffer;
+```
+
+## writeConsoleInput
+
+Writes data to the console input buffer, returning the number of bytes actually written. Requires the runtime console input source to be set to `from_buffer`.
+
+```ts
+writeConsoleInput(data: Buffer): bigint;
+```
+
 ## run
 
 Runs the machine until the given cycle, or until it yields or halts. If no argument is provided, runs until `MAX_MCYCLE` (the maximum cycle value), which is equivalent to running until the machine yields or halts.
@@ -289,6 +351,31 @@ Resets the entire microarchitecture state to pristine values.
 resetUarch(): void;
 ```
 
+## collectMcycleRootHashes
+
+Collects the root hashes after every `mcyclePeriod` machine cycles until mcycle reaches `mcycleEnd`, the machine yields, or halts.
+
+```ts
+collectMcycleRootHashes(
+    mcycleEnd: bigint,
+    mcyclePeriod: bigint,
+    mcyclePhase?: bigint,
+    log2BundleMcycleCount?: number,
+    previousBackTree?: unknown,
+): McycleRootHashes;
+```
+
+## collectUarchCycleRootHashes
+
+Collects the root hashes after every microarchitecture cycle until mcycle reaches `mcycleEnd`, the machine yields, or halts, implicitly resetting the microarchitecture between machine cycles.
+
+```ts
+collectUarchCycleRootHashes(
+    mcycleEnd: bigint,
+    log2BundleUarchCycleCount?: number,
+): UarchCycleRootHashes;
+```
+
 ## getRootHash
 
 Obtains the root hash of the current machine state.
@@ -297,28 +384,36 @@ Obtains the root hash of the current machine state.
 getRootHash(): Buffer;
 ```
 
+## getNodeHash
+
+Obtains the hash of a node in the machine state hash tree.
+
+```ts
+getNodeHash(address: bigint, log2Size: number): Buffer;
+```
+
 ## getProof
 
-Obtains a Merkle proof for a range in the machine state.
+Obtains a proof for a node in the machine state hash tree. `log2RootSize` defaults to `Constant.HashTreeLog2RootSize` (the entire address space), and can be lowered to obtain a proof relative to a subtree root.
 
 ```ts
-getProof(address: bigint, log2Size: number): Proof;
+getProof(address: bigint, log2TargetSize: number, log2RootSize?: number): Proof;
 ```
 
-## verifyMerkleTree
+## verifyHashTree
 
-Verifies the integrity of the Merkle tree against the current machine state.
+Verifies the integrity of the hash tree against the current machine state.
 
 ```ts
-verifyMerkleTree(): boolean;
+verifyHashTree(): boolean;
 ```
 
-## verifyDirtyPageMaps
+## getHashTreeStats
 
-Verifies the integrity of the dirty page maps.
+Obtains hash tree statistics, optionally clearing them after retrieval.
 
 ```ts
-verifyDirtyPageMaps(): boolean;
+getHashTreeStats(clear?: boolean): HashTreeStats;
 ```
 
 ## logStep

--- a/apps/docs/pages/cm/api/create.mdx
+++ b/apps/docs/pages/cm/api/create.mdx
@@ -5,8 +5,10 @@ Creates a new local Cartesi machine instance from the given configuration and op
 ## Function Signature
 
 ```ts
-create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig): CartesiMachine
+create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig, dir?: string): CartesiMachine
 ```
+
+If `dir` is provided, the machine is created with on-disk state at that directory. Otherwise the machine is created in-memory.
 
 ## Example
 
@@ -16,11 +18,15 @@ import { create, BreakReason } from "@deroll/cm";
 const machine = create({
     ram: {
         length: 0x8000000, // 128MB of RAM
-        image_filename: "linux.bin",
+        backing_store: {
+            data_filename: "linux.bin",
+        },
     },
     flash_drive: [
         {
-            image_filename: "rootfs.ext2",
+            backing_store: {
+                data_filename: "rootfs.ext2",
+            },
         },
     ],
     dtb: {

--- a/apps/docs/pages/cm/api/load.mdx
+++ b/apps/docs/pages/cm/api/load.mdx
@@ -5,8 +5,14 @@ Loads a Cartesi machine instance from a previously stored directory, with option
 ## Function Signature
 
 ```ts
-load(dir: string, runtimeConfig?: MachineRuntimeConfig): CartesiMachine
+load(dir: string, runtimeConfig?: MachineRuntimeConfig, sharing?: SharingMode): CartesiMachine
 ```
+
+The `sharing` parameter controls how the loaded machine state relates to the backing stores on disk:
+
+- `SharingMode.None` (default): machine state is fully in-memory
+- `SharingMode.Config`: machine state is on-disk for backing stores marked as shared in the machine configuration, in-memory for everything else
+- `SharingMode.All`: machine state is fully on-disk
 
 ## Example
 

--- a/apps/docs/pages/cm/api/remote-cartesi-machine.mdx
+++ b/apps/docs/pages/cm/api/remote-cartesi-machine.mdx
@@ -20,10 +20,10 @@ export interface RemoteCartesiMachine extends CartesiMachine {
     delayNextRequest(ms: number): void;
     getBoundAddress(): string | null;
     fork(): RemoteCartesiMachine;
-    load(dir: string, runtimeConfig?: MachineRuntimeConfig): RemoteCartesiMachine;
-    create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig): RemoteCartesiMachine;
+    load(dir: string, runtimeConfig?: MachineRuntimeConfig, sharing?: SharingMode): RemoteCartesiMachine;
+    create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig, dir?: string): RemoteCartesiMachine;
     cloneEmpty(): RemoteCartesiMachine;
-    store(dir: string): RemoteCartesiMachine;
+    store(dir: string, sharing?: SharingMode): RemoteCartesiMachine;
 }
 ```
 
@@ -136,7 +136,7 @@ fork(): RemoteCartesiMachine;
 Loads a remote machine instance from a previously stored directory, with optional runtime configuration. Returns a `RemoteCartesiMachine` instance, allowing method chaining. Semantics are the same as for [CartesiMachine.load](/cm/api/cartesi-machine#load).
 
 ```ts
-load(dir: string, runtimeConfig?: MachineRuntimeConfig): RemoteCartesiMachine
+load(dir: string, runtimeConfig?: MachineRuntimeConfig, sharing?: SharingMode): RemoteCartesiMachine
 ```
 
 ## create
@@ -144,7 +144,7 @@ load(dir: string, runtimeConfig?: MachineRuntimeConfig): RemoteCartesiMachine
 Creates a new remote machine instance from the given configuration and optional runtime configuration. Returns a `RemoteCartesiMachine` instance, allowing method chaining. Semantics are the same as for [CartesiMachine.create](/cm/api/cartesi-machine#create).
 
 ```ts
-create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig): RemoteCartesiMachine
+create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig, dir?: string): RemoteCartesiMachine
 ```
 
 ## cloneEmpty
@@ -160,5 +160,5 @@ cloneEmpty(): RemoteCartesiMachine
 Stores the current remote machine instance to a directory, serializing its entire state. Returns a `RemoteCartesiMachine` instance, allowing method chaining. Semantics are the same as for [CartesiMachine.store](/cm/api/cartesi-machine#store).
 
 ```ts
-store(dir: string): RemoteCartesiMachine
+store(dir: string, sharing?: SharingMode): RemoteCartesiMachine
 ```

--- a/apps/docs/pages/cm/index.mdx
+++ b/apps/docs/pages/cm/index.mdx
@@ -13,7 +13,7 @@ It provides a fully typed and ergonomic TypeScript API for the Cartesi Machine C
 
 ## Installation
 
-Make sure you install the Cartesi Machine [0.19.0](https://github.com/cartesi/machine-emulator/releases/tag/v0.19.0) library in your system by following the official [instructions](https://github.com/cartesi/machine-emulator?tab=readme-ov-file#installation).
+Make sure you install the Cartesi Machine [0.20.0](https://github.com/cartesi/machine-emulator/releases/tag/v0.20.0) library in your system by following the official [instructions](https://github.com/cartesi/machine-emulator?tab=readme-ov-file#installation).
 
 Then install this package
 

--- a/apps/docs/pages/cm/local.mdx
+++ b/apps/docs/pages/cm/local.mdx
@@ -5,10 +5,12 @@ It can be created by using the following utility methods:
 
 ```ts
 // create a new machine from a configuration
-function create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig): CartesiMachine;
+// if dir is provided, the machine is created with on-disk state at that directory
+function create(config: MachineConfig, runtimeConfig?: MachineRuntimeConfig, dir?: string): CartesiMachine;
 
 // load machine snapshot saved to a directory
-function load(dir: string, runtimeConfig?: MachineRuntimeConfig): CartesiMachine;
+// sharing controls whether machine state is in-memory (default) or on-disk
+function load(dir: string, runtimeConfig?: MachineRuntimeConfig, sharing?: SharingMode): CartesiMachine;
 
 // create an empty machine, which later must be created or loaded
 function empty(): CartesiMachine;
@@ -29,11 +31,15 @@ import { create } from "@deroll/cm";
 const machine = create({
     ram: {
         length: 0x8000000, // 128MB of RAM
-        image_filename: "linux.bin",
+        backing_store: {
+            data_filename: "linux.bin",
+        },
     },
     flash_drive: [
         {
-            image_filename: "rootfs.ext2",
+            backing_store: {
+                data_filename: "rootfs.ext2",
+            },
         },
     ],
     dtb: {
@@ -55,11 +61,15 @@ import { BreakReason, create } from "@deroll/cm"; // [!code ++] // [!code focus]
 const machine = create({
     ram: {
         length: 0x8000000, // 128MB of RAM
-        image_filename: "linux.bin",
+        backing_store: {
+            data_filename: "linux.bin",
+        },
     },
     flash_drive: [
         {
-            image_filename: "rootfs.ext2",
+            backing_store: {
+                data_filename: "rootfs.ext2",
+            },
         },
     ],
     dtb: {
@@ -93,11 +103,15 @@ import { BreakReason, create } from "@deroll/cm";
 const machine = create({
     ram: {
         length: 0x8000000, // 128MB of RAM
-        image_filename: "linux.bin",
+        backing_store: {
+            data_filename: "linux.bin",
+        },
     },
     flash_drive: [
         {
-            image_filename: "rootfs.ext2",
+            backing_store: {
+                data_filename: "rootfs.ext2",
+            },
         },
     ],
     dtb: {

--- a/apps/docs/pages/cm/remote.mdx
+++ b/apps/docs/pages/cm/remote.mdx
@@ -21,11 +21,15 @@ const machine = create({ // [!code --]
 const machine = spawn().create({ // [!code ++]
     ram: {
         length: 0x8000000, // 128MB of RAM
-        image_filename: "linux.bin",
+        backing_store: {
+            data_filename: "linux.bin",
+        },
     },
     flash_drive: [
         {
-            image_filename: "rootfs.ext2",
+            backing_store: {
+                data_filename: "rootfs.ext2",
+            },
         },
     ],
     dtb: {

--- a/apps/docs/snippets/cm/local.ts
+++ b/apps/docs/snippets/cm/local.ts
@@ -4,11 +4,15 @@ import { BreakReason, create } from "@deroll/cm";
 const machine = create({
     ram: {
         length: 0x8000000, // 128MB of RAM
-        image_filename: "linux.bin",
+        backing_store: {
+            data_filename: "linux.bin",
+        },
     },
     flash_drive: [
         {
-            image_filename: "rootfs.ext2",
+            backing_store: {
+                data_filename: "rootfs.ext2",
+            },
         },
     ],
     dtb: {

--- a/apps/docs/snippets/cm/remote.ts
+++ b/apps/docs/snippets/cm/remote.ts
@@ -3,11 +3,15 @@ import { BreakReason, spawn } from "@deroll/cm";
 const machine = spawn().create({
     ram: {
         length: 0x8000000, // 128MB of RAM
-        image_filename: "linux.bin",
+        backing_store: {
+            data_filename: "linux.bin",
+        },
     },
     flash_drive: [
         {
-            image_filename: "rootfs.ext2",
+            backing_store: {
+                data_filename: "rootfs.ext2",
+            },
         },
     ],
     dtb: {

--- a/packages/bindings/cm/examples/cartesi-machine.ts
+++ b/packages/bindings/cm/examples/cartesi-machine.ts
@@ -18,11 +18,15 @@ async function basicMachineExample() {
         const config = {
             ram: {
                 length: 0x8000000,
-                image_filename: "linux.bin",
+                backing_store: {
+                    data_filename: "linux.bin",
+                },
             },
             flash_drive: [
                 {
-                    image_filename: "rootfs.ext2",
+                    backing_store: {
+                        data_filename: "rootfs.ext2",
+                    },
                 },
             ],
             dtb: {
@@ -41,9 +45,9 @@ async function basicMachineExample() {
         const initialConfig = machine.getInitialConfig();
         console.log("Initial configuration:", initialConfig);
 
-        // Get memory ranges
-        const memoryRanges = machine.getMemoryRanges();
-        console.log("Memory ranges:", memoryRanges);
+        // Get address ranges
+        const addressRanges = machine.getAddressRanges();
+        console.log("Address ranges:", addressRanges);
 
         // Get root hash
         const rootHash = machine.getRootHash();
@@ -170,10 +174,10 @@ async function registerOperationsExample() {
 }
 
 /**
- * Example demonstrating Merkle tree operations
+ * Example demonstrating hash tree operations
  */
-async function merkleTreeExample() {
-    console.log("\n=== Merkle Tree Example ===");
+async function hashTreeExample() {
+    console.log("\n=== Hash Tree Example ===");
 
     try {
         // Create a machine
@@ -192,7 +196,7 @@ async function merkleTreeExample() {
 
         // Get proof for a memory address
         const address = 0x80000000n;
-        const log2Size = Constant.TreeLog2WordSize; // Word size
+        const log2Size = Constant.HashTreeLog2WordSize; // Word size
         console.log(
             `Getting proof for address 0x${address.toString(16)} with log2_size ${log2Size}...`,
         );
@@ -200,21 +204,18 @@ async function merkleTreeExample() {
         const proof = machine.getProof(address, log2Size);
         console.log("Proof:", proof);
 
-        // Verify Merkle tree integrity
-        console.log("Verifying Merkle tree integrity...");
-        const isIntegrityValid = machine.verifyMerkleTree();
+        // Verify hash tree integrity
+        console.log("Verifying hash tree integrity...");
+        const isIntegrityValid = machine.verifyHashTree();
         console.log(
-            "Merkle tree integrity:",
+            "Hash tree integrity:",
             isIntegrityValid ? "Valid" : "Invalid",
         );
 
-        // Verify dirty page maps
-        console.log("Verifying dirty page maps...");
-        const areDirtyMapsValid = machine.verifyDirtyPageMaps();
-        console.log(
-            "Dirty page maps:",
-            areDirtyMapsValid ? "Valid" : "Invalid",
-        );
+        // Get hash tree statistics
+        console.log("Getting hash tree statistics...");
+        const stats = machine.getHashTreeStats();
+        console.log("Hash tree stats:", stats);
     } catch (error) {
         console.error("Error:", error);
     }
@@ -320,7 +321,7 @@ async function main() {
     await basicMachineExample();
     await memoryOperationsExample();
     await registerOperationsExample();
-    await merkleTreeExample();
+    await hashTreeExample();
     await executionExample();
     await errorHandlingExample();
 

--- a/packages/bindings/cm/examples/cartesi-remote-machine.ts
+++ b/packages/bindings/cm/examples/cartesi-remote-machine.ts
@@ -42,11 +42,15 @@ async function example() {
         const config = {
             ram: {
                 length: 0x8000000,
-                image_filename: "linux.bin",
+                backing_store: {
+                    data_filename: "linux.bin",
+                },
             },
             flash_drive: [
                 {
-                    image_filename: "rootfs.ext2",
+                    backing_store: {
+                        data_filename: "rootfs.ext2",
+                    },
                 },
             ],
             dtb: {

--- a/packages/bindings/cm/examples/error-handling-example.ts
+++ b/packages/bindings/cm/examples/error-handling-example.ts
@@ -74,7 +74,9 @@ async function demonstrateErrorHandling() {
             const _machine = create({
                 ram: {
                     length: 0x8000000,
-                    image_filename: "nonexistent.bin",
+                    backing_store: {
+                        data_filename: "nonexistent.bin",
+                    },
                 },
             });
         } catch (error) {

--- a/packages/bindings/cm/jsonrpc-discover.json
+++ b/packages/bindings/cm/jsonrpc-discover.json
@@ -2,7 +2,7 @@
     "openrpc": "1.0.0-rc1",
     "info": {
         "title": "Remote Cartesi Machine",
-        "version": "0.5.0",
+        "version": "0.6.0",
         "description": "API for controlling a remote Cartesi Machine server",
         "license": {
             "name": "MIT"
@@ -130,6 +130,13 @@
                     "schema": {
                         "$ref": "#/components/schemas/MachineRuntimeConfig"
                     }
+                },
+                {
+                    "name": "directory",
+                    "description": "Directory to create an on-disk machine instance",
+                    "schema": {
+                        "type": "string"
+                    }
                 }
             ],
             "result": {
@@ -159,6 +166,14 @@
                     "schema": {
                         "$ref": "#/components/schemas/MachineRuntimeConfig"
                     }
+                },
+                {
+                    "name": "sharing",
+                    "description": "Backing stores sharing mode",
+                    "required": false,
+                    "schema": {
+                        "$ref": "#/components/schemas/SharingMode"
+                    }
                 }
             ],
             "result": {
@@ -187,6 +202,64 @@
             "params": [
                 {
                     "name": "directory",
+                    "description": "Directory to stored machine instance",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "name": "sharing",
+                    "description": "Backing stores sharing mode",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/SharingMode"
+                    }
+                }
+            ],
+            "result": {
+                "name": "status",
+                "description": "True when operation succeeded",
+                "schema": {
+                    "type": "boolean"
+                }
+            }
+        },
+        {
+            "name": "machine.clone_stored",
+            "summary": "Clones a machine stored from source directory to destination directory",
+            "params": [
+                {
+                    "name": "from_dir",
+                    "description": "Source directory",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "name": "to_dir",
+                    "description": "Destination directory",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "result": {
+                "name": "status",
+                "description": "True when operation succeeded",
+                "schema": {
+                    "type": "boolean"
+                }
+            }
+        },
+        {
+            "name": "machine.remove_stored",
+            "summary": "Removes a stored machine instance from a directory",
+            "params": [
+                {
+                    "name": "dir",
                     "description": "Directory to stored machine instance",
                     "required": true,
                     "schema": {
@@ -224,6 +297,51 @@
             }
         },
         {
+            "name": "machine.collect_mcycle_root_hashes",
+            "summary": "Collect root hashes periodically while running the emulator",
+            "params": [
+                {
+                    "name": "mcycle_end",
+                    "description": "End machine cycle value",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                },
+                {
+                    "name": "mcycle_period",
+                    "description": "Number of machine cycles between root hashes to collect",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                },
+                {
+                    "name": "mcycle_phase",
+                    "description": "Number of machine cycles elapsed since last root hash collected",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                },
+                {
+                    "name": "log2_bundle_mcycle_count",
+                    "description": "Log base 2 of the amount of mcycle root hashes to bundle",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "description": "Collected hashes",
+                "schema": {
+                    "$ref": "#/components/schemas/McycleRootHashes"
+                }
+            }
+        },
+        {
             "name": "machine.run_uarch",
             "summary": "Runs the small emulator until a given cycle",
             "params": [
@@ -241,6 +359,35 @@
                 "description": "Reason call returned",
                 "schema": {
                     "$ref": "#/components/schemas/UarchInterpreterBreakReason"
+                }
+            }
+        },
+        {
+            "name": "machine.collect_uarch_cycle_root_hashes",
+            "summary": "Collect root hashes while running the emulator's uarch",
+            "params": [
+                {
+                    "name": "mcycle_end",
+                    "description": "End machine cycle value to execute, uarch cycle by uarch cycle",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                },
+                {
+                    "name": "log2_bundle_uarch_cycle_count",
+                    "description": "Log base 2 of the amount of uarch cycle root hashes to bundle",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "description": "Collected hashes",
+                "schema": {
+                    "$ref": "#/components/schemas/UarchCycleRootHashes"
                 }
             }
         },
@@ -341,11 +488,11 @@
         },
         {
             "name": "machine.get_root_hash",
-            "summary": "Obtains the Merkle hash of the current machine state",
+            "summary": "Obtains the hash-tree root hash of the current machine state",
             "params": [],
             "result": {
                 "name": "hash",
-                "description": "Merkle hash",
+                "description": "Root hash",
                 "schema": {
                     "$ref": "#/components/schemas/Base64Hash"
                 }
@@ -353,7 +500,7 @@
         },
         {
             "name": "machine.get_proof",
-            "summary": "Obtains a Merkle proof for a range in the machine state",
+            "summary": "Obtains a hash-tree proof for a range in the machine state",
             "params": [
                 {
                     "name": "address",
@@ -364,11 +511,24 @@
                     }
                 },
                 {
-                    "name": "log2_size",
-                    "description": "Log2 of size of range",
+                    "name": "log2_target_size",
+                    "description": "Log2 of size of target range",
                     "required": true,
                     "schema": {
-                        "$ref": "#/components/schemas/UnsignedInteger"
+                        "$ref": "#/components/schemas/UnsignedInteger",
+                        "minimum": 5,
+                        "maximum": 64
+                    }
+                },
+                {
+                    "name": "log2_root_size",
+                    "description": "Log2 of size of enclosing range",
+                    "required": false,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger",
+                        "minimum": 5,
+                        "maximum": 64,
+                        "default": 64
                     }
                 }
             ],
@@ -377,6 +537,27 @@
                 "description": "Proof of range contents",
                 "schema": {
                     "$ref": "#/components/schemas/Proof"
+                }
+            }
+        },
+        {
+            "name": "machine.get_hash_tree_stats",
+            "summary": "Returns statistics for the hash tree",
+            "params": [
+                {
+                    "name": "clear",
+                    "description": "Whether to clear the stats after retrieving them",
+                    "required": true,
+                    "schema": {
+                        "type": "boolean"
+                    }
+                }
+            ],
+            "result": {
+                "name": "stats",
+                "description": "Statistics for the hash tree",
+                "schema": {
+                    "$ref": "#/components/schemas/HashTreeStats"
                 }
             }
         },
@@ -398,6 +579,35 @@
                 "description": "Value of word (little-endian)",
                 "schema": {
                     "$ref": "#/components/schemas/UnsignedInteger"
+                }
+            }
+        },
+        {
+            "name": "machine.write_word",
+            "summary": "Writes a 64-bit word from memory (must be aligned)",
+            "params": [
+                {
+                    "name": "address",
+                    "description": "Starting physical address of word",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                },
+                {
+                    "name": "value",
+                    "description": "Value of word (little-endian)",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                }
+            ],
+            "result": {
+                "name": "status",
+                "description": "True when operation succeeded",
+                "schema": {
+                    "type": "boolean"
                 }
             }
         },
@@ -533,6 +743,65 @@
             "result": {
                 "name": "paddr",
                 "description": "Value of corresponding physical address (little-endian)",
+                "schema": {
+                    "$ref": "#/components/schemas/UnsignedInteger"
+                }
+            }
+        },
+        {
+            "name": "machine.read_console_output",
+            "summary": "Reads and consumes data from the console output buffer",
+            "params": [
+                {
+                    "name": "max_length",
+                    "description": "Maximum number of bytes to read",
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "description": "Console output data or available read length",
+                "schema": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/components/schemas/Base64String"
+                                }
+                            },
+                            "required": ["data"]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "read_len": {
+                                    "$ref": "#/components/schemas/UnsignedInteger"
+                                }
+                            },
+                            "required": ["read_len"]
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "machine.write_console_input",
+            "summary": "Writes data to the console input buffer",
+            "params": [
+                {
+                    "name": "data",
+                    "description": "Data to write to console input buffer",
+                    "schema": {
+                        "$ref": "#/components/schemas/Base64String"
+                    }
+                }
+            ],
+            "result": {
+                "name": "written_len",
+                "description": "Number of bytes actually written",
                 "schema": {
                     "$ref": "#/components/schemas/UnsignedInteger"
                 }
@@ -688,38 +957,26 @@
             }
         },
         {
-            "name": "machine.verify_merkle_tree",
-            "summary": "Verifies sanity of Merkle tree",
+            "name": "machine.verify_hash_tree",
+            "summary": "Verifies sanity of hash tree",
             "params": [],
             "result": {
                 "name": "valid",
-                "description": "True if Merkle tree is sane",
+                "description": "True if hash tree is sane",
                 "schema": {
                     "type": "boolean"
                 }
             }
         },
         {
-            "name": "machine.verify_dirty_page_maps",
-            "summary": "Verifies sanity of dirty page maps",
-            "params": [],
-            "result": {
-                "name": "valid",
-                "description": "True if dirty page maps are sane",
-                "schema": {
-                    "type": "boolean"
-                }
-            }
-        },
-        {
-            "name": "machine.get_memory_ranges",
-            "summary": "Returns a list with descriptions for all of the machine's memory ranges",
+            "name": "machine.get_address_ranges",
+            "summary": "Returns a list with descriptions for all of the machine's address ranges",
             "params": [],
             "result": {
                 "name": "ranges",
-                "description": "Array of memory range descriptions",
+                "description": "Array of address range descriptions",
                 "schema": {
-                    "$ref": "#/components/schemas/MemoryRangeDescriptionArray"
+                    "$ref": "#/components/schemas/AddressRangeDescriptionArray"
                 }
             }
         },
@@ -958,21 +1215,128 @@
                     }
                 }
             },
+            "ConsoleOutputDestination": {
+                "title": "ConsoleOutputDestination",
+                "enum": [
+                    "to_null",
+                    "to_stdout",
+                    "to_stderr",
+                    "to_fd",
+                    "to_file",
+                    "to_buffer"
+                ]
+            },
+            "ConsoleFlushMode": {
+                "title": "ConsoleFlushMode",
+                "enum": ["when_full", "every_char", "every_line"]
+            },
+            "ConsoleInputSource": {
+                "title": "ConsoleInputSource",
+                "enum": [
+                    "from_null",
+                    "from_stdin",
+                    "from_fd",
+                    "from_file",
+                    "from_buffer"
+                ]
+            },
+            "ConsoleRuntimeConfig": {
+                "title": "ConsoleRuntimeConfig",
+                "type": "object",
+                "properties": {
+                    "output_destination": {
+                        "$ref": "#/components/schemas/ConsoleOutputDestination"
+                    },
+                    "output_flush_mode": {
+                        "$ref": "#/components/schemas/ConsoleFlushMode"
+                    },
+                    "output_buffer_size": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "output_fd": {
+                        "type": "integer"
+                    },
+                    "output_filename": {
+                        "type": "string"
+                    },
+                    "input_source": {
+                        "$ref": "#/components/schemas/ConsoleInputSource"
+                    },
+                    "input_buffer_size": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "input_fd": {
+                        "type": "integer"
+                    },
+                    "input_filename": {
+                        "type": "string"
+                    },
+                    "tty_cols": {
+                        "type": "integer"
+                    },
+                    "tty_rows": {
+                        "type": "integer"
+                    }
+                }
+            },
             "ConcurrencyRuntimeConfig": {
                 "title": "ConcurrencyRuntimeConfig",
                 "type": "object",
                 "properties": {
-                    "update_merkle_tree": {
+                    "update_hash_tree": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     }
                 }
             },
-            "HTIFRuntimeConfig": {
-                "title": "HTIFRuntimeConfig",
+            "HashTreeStats": {
+                "title": "HashTreeStats",
                 "type": "object",
                 "properties": {
-                    "no_console_putchar": {
-                        "type": "boolean"
+                    "phtc": {
+                        "$ref": "#/components/schemas/PageHashTreeCacheStats"
+                    },
+                    "sparse_node_hashes": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "dense_node_hashes": {
+                        "$ref": "#/components/schemas/UnsignedIntegerArray"
+                    }
+                }
+            },
+            "UnsignedIntegerArray": {
+                "title": "UnsignedIntegerArray",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/UnsignedInteger"
+                }
+            },
+            "PageHashTreeCacheStats": {
+                "title": "PageHashTreeCacheStats",
+                "type": "object",
+                "properties": {
+                    "page_hits": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "page_misses": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "word_hits": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "word_misses": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "page_changes": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "inner_page_hashes": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "pristine_pages": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "non_pristine_pages": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
                     }
                 }
             },
@@ -980,28 +1344,37 @@
                 "title": "MachineRuntimeConfig",
                 "type": "object",
                 "properties": {
+                    "console": {
+                        "$ref": "#/components/schemas/ConsoleRuntimeConfig"
+                    },
                     "concurrency": {
                         "$ref": "#/components/schemas/ConcurrencyRuntimeConfig"
-                    },
-                    "htif": {
-                        "$ref": "#/components/schemas/HTIFRuntimeConfig"
-                    },
-                    "skip_root_hash_check": {
-                        "type": "boolean"
-                    },
-                    "skip_root_hash_store": {
-                        "type": "boolean"
                     },
                     "skip_version_check": {
                         "type": "boolean"
                     },
                     "soft_yield": {
                         "type": "boolean"
+                    },
+                    "no_reserve": {
+                        "type": "boolean"
                     }
                 }
             },
             "ProcessorConfig": {
                 "title": "ProcessorConfig",
+                "type": "object",
+                "properties": {
+                    "registers": {
+                        "$ref": "#/components/schemas/RegistersConfig"
+                    },
+                    "backing_store": {
+                        "$ref": "#/components/schemas/BackingStoreConfig"
+                    }
+                }
+            },
+            "RegistersConfig": {
+                "title": "RegistersConfig",
                 "type": "object",
                 "properties": {
                     "x0": {
@@ -1307,8 +1680,8 @@
                     "length": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     },
-                    "image_filename": {
-                        "type": "string"
+                    "backing_store": {
+                        "$ref": "#/components/schemas/BackingStoreConfig"
                     }
                 },
                 "required": ["length"]
@@ -1326,8 +1699,8 @@
                     "entrypoint": {
                         "type": "string"
                     },
-                    "image_filename": {
-                        "type": "string"
+                    "backing_store": {
+                        "$ref": "#/components/schemas/BackingStoreConfig"
                     }
                 }
             },
@@ -1341,23 +1714,41 @@
                     "length": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     },
-                    "image_filename": {
+                    "read_only": {
+                        "type": "boolean"
+                    },
+                    "backing_store": {
+                        "$ref": "#/components/schemas/BackingStoreConfig"
+                    }
+                }
+            },
+            "BackingStoreConfig": {
+                "title": "BackingStoreConfig",
+                "type": "object",
+                "properties": {
+                    "data_filename": {
+                        "type": "string"
+                    },
+                    "dht_filename": {
                         "type": "string"
                     },
                     "shared": {
+                        "type": "boolean"
+                    },
+                    "create": {
+                        "type": "boolean"
+                    },
+                    "truncate": {
                         "type": "boolean"
                     }
                 }
             },
-            "CmioBufferConfig": {
-                "title": "CmioBufferConfig",
+            "CMIOBufferConfig": {
+                "title": "CMIOBufferConfig",
                 "type": "object",
                 "properties": {
-                    "image_filename": {
-                        "type": "string"
-                    },
-                    "shared": {
-                        "type": "boolean"
+                    "backing_store": {
+                        "$ref": "#/components/schemas/BackingStoreConfig"
                     }
                 }
             },
@@ -1422,15 +1813,6 @@
                     "$ref": "#/components/schemas/MemoryRangeConfig"
                 }
             },
-            "TLBConfig": {
-                "title": "TLBConfig",
-                "type": "object",
-                "properties": {
-                    "image_filename": {
-                        "type": "string"
-                    }
-                }
-            },
             "CLINTConfig": {
                 "title": "CLINTConfig",
                 "type": "object",
@@ -1475,6 +1857,18 @@
             },
             "UarchProcessorConfig": {
                 "title": "UarchProcessorConfig",
+                "type": "object",
+                "properties": {
+                    "registers": {
+                        "$ref": "#/components/schemas/UarchRegistersConfig"
+                    },
+                    "backing_store": {
+                        "$ref": "#/components/schemas/BackingStoreConfig"
+                    }
+                }
+            },
+            "UarchRegistersConfig": {
+                "title": "UarchRegistersConfig",
                 "type": "object",
                 "properties": {
                     "x0": {
@@ -1580,7 +1974,7 @@
                         "$ref": "#/components/schemas/UnsignedInteger"
                     },
                     "halt_flag": {
-                        "type": "boolean"
+                        "$ref": "#/components/schemas/UnsignedInteger"
                     }
                 }
             },
@@ -1591,8 +1985,8 @@
                     "length": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     },
-                    "image_filename": {
-                        "type": "string"
+                    "backing_store": {
+                        "$ref": "#/components/schemas/BackingStoreConfig"
                     }
                 }
             },
@@ -1608,15 +2002,48 @@
                     }
                 }
             },
-            "CmioConfig": {
-                "title": "CmioConfig",
+            "CMIOConfig": {
+                "title": "CMIOConfig",
                 "type": "object",
                 "properties": {
                     "rx_buffer": {
-                        "$ref": "#/components/schemas/CmioBufferConfig"
+                        "$ref": "#/components/schemas/CMIOBufferConfig"
                     },
                     "tx_buffer": {
-                        "$ref": "#/components/schemas/CmioBufferConfig"
+                        "$ref": "#/components/schemas/CMIOBufferConfig"
+                    }
+                }
+            },
+            "PMAsConfig": {
+                "title": "PMAsConfig",
+                "type": "object",
+                "properties": {
+                    "backing_store": {
+                        "$ref": "#/components/schemas/BackingStoreConfig"
+                    }
+                }
+            },
+            "HashTreeConfig": {
+                "title": "HashTreeConfig",
+                "type": "object",
+                "properties": {
+                    "shared": {
+                        "type": "boolean"
+                    },
+                    "create": {
+                        "type": "boolean"
+                    },
+                    "sht_filename": {
+                        "type": "string"
+                    },
+                    "phtc_filename": {
+                        "type": "string"
+                    },
+                    "phtc_size": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "hash_function": {
+                        "$ref": "#/components/schemas/HashFunctionType"
                     }
                 }
             },
@@ -1643,9 +2070,6 @@
                     "flash_drive": {
                         "$ref": "#/components/schemas/FlashDriveConfigs"
                     },
-                    "tlb": {
-                        "$ref": "#/components/schemas/TLBConfig"
-                    },
                     "clint": {
                         "$ref": "#/components/schemas/CLINTConfig"
                     },
@@ -1655,17 +2079,27 @@
                     "htif": {
                         "$ref": "#/components/schemas/HTIFConfig"
                     },
+                    "virtio": {
+                        "$ref": "#/components/schemas/VirtIOConfigs"
+                    },
+                    "cmio": {
+                        "$ref": "#/components/schemas/CMIOConfig"
+                    },
+                    "pmas": {
+                        "$ref": "#/components/schemas/PMAsConfig"
+                    },
                     "uarch": {
                         "$ref": "#/components/schemas/UarchConfig"
                     },
-                    "cmio": {
-                        "$ref": "#/components/schemas/CmioConfig"
-                    },
-                    "virtio": {
-                        "$ref": "#/components/schemas/VirtIOConfigs"
+                    "hash_tree": {
+                        "$ref": "#/components/schemas/HashTreeConfig"
                     }
                 },
                 "required": ["ram"]
+            },
+            "HashFunctionType": {
+                "title": "HashFunctionType",
+                "enum": ["keccak256", "sha256"]
             },
             "InterpreterBreakReason": {
                 "title": "InterpreterBreakReason",
@@ -1675,12 +2109,18 @@
                     "yielded_manually",
                     "yielded_automatically",
                     "yielded_softly",
-                    "reached_target_mcycle"
+                    "reached_target_mcycle",
+                    "console_output",
+                    "console_input"
                 ]
             },
             "UarchInterpreterBreakReason": {
                 "title": "UarchInterpreterBreakReason",
-                "enum": ["reached_target_cycle", "uarch_halted"]
+                "enum": [
+                    "reached_target_cycle",
+                    "uarch_halted",
+                    "cycle_overflow"
+                ]
             },
             "Base64String": {
                 "title": "Base64String",
@@ -1842,6 +2282,10 @@
                 },
                 "required": ["log_type", "accesses"]
             },
+            "SharingMode": {
+                "title": "SharingMode",
+                "enum": ["none", "config", "all"]
+            },
             "REG": {
                 "title": "REG",
                 "enum": [
@@ -1996,8 +2440,8 @@
                     "uarch_halt_flag"
                 ]
             },
-            "MemoryRangeDescription": {
-                "title": "MemoryRangeDescription",
+            "AddressRangeDescription": {
+                "title": "AddressRangeDescription",
                 "type": "object",
                 "properties": {
                     "start": {
@@ -2011,12 +2455,74 @@
                     }
                 }
             },
-            "MemoryRangeDescriptionArray": {
-                "title": "MemoryRangeDescriptionArray",
+            "AddressRangeDescriptionArray": {
+                "title": "AddressRangeDescriptionArray",
                 "type": "array",
                 "items": {
-                    "$ref": "#/components/schemas/MemoryRangeDescription"
+                    "$ref": "#/components/schemas/AddressRangeDescription"
                 }
+            },
+            "McycleRootHashes": {
+                "title": "McycleRootHashes",
+                "type": "object",
+                "properties": {
+                    "hashes": {
+                        "$ref": "#/components/schemas/Base64HashArray"
+                    },
+                    "mcycle_phase": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "break_reason": {
+                        "$ref": "#/components/schemas/InterpreterBreakReason"
+                    },
+                    "back_tree": {
+                        "$ref": "#/components/schemas/BackMerkleTree"
+                    },
+                    "console_io_error": {
+                        "type": "string"
+                    }
+                },
+                "required": ["hashes", "mcycle_phase", "break_reason"]
+            },
+            "UarchCycleRootHashes": {
+                "title": "UarchCycleRootHashes",
+                "type": "object",
+                "properties": {
+                    "hashes": {
+                        "$ref": "#/components/schemas/Base64HashArray"
+                    },
+                    "reset_indices": {
+                        "$ref": "#/components/schemas/UnsignedIntegerArray"
+                    },
+                    "break_reason": {
+                        "$ref": "#/components/schemas/InterpreterBreakReason"
+                    }
+                },
+                "required": ["hashes", "reset_indices", "break_reason"]
+            },
+            "BackMerkleTree": {
+                "title": "BackMerkleTree",
+                "type": "object",
+                "properties": {
+                    "log2_max_leaves": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "hash_function": {
+                        "$ref": "#/components/schemas/HashFunctionType"
+                    },
+                    "leaf_count": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "context": {
+                        "$ref": "#/components/schemas/Base64HashArray"
+                    }
+                },
+                "required": [
+                    "log2_max_leaves",
+                    "hash_function",
+                    "leaf_count",
+                    "context"
+                ]
             }
         }
     }

--- a/packages/bindings/cm/src/cartesi-machine.ts
+++ b/packages/bindings/cm/src/cartesi-machine.ts
@@ -2,10 +2,14 @@ import { NodeCartesiMachine } from "./node/cartesi-machine.js";
 import type {
     AccessLog,
     AccessLogType,
+    AddressRangeDescription,
+    HashTreeStats,
     MachineConfig,
     MachineRuntimeConfig,
-    MemoryRangeDescription,
+    McycleRootHashes,
+    MemoryRangeConfig,
     Proof,
+    UarchCycleRootHashes,
 } from "./types.js";
 
 // -----------------------------------------------------------------------------
@@ -15,23 +19,35 @@ import type {
 /**
  * The maximum value for mcycle
  */
-export const MAX_MCYCLE = 0xffffffffffffffffffn;
+export const MAX_MCYCLE = 0xffffffffffffffffn;
+
+/**
+ * The maximum value for uarch_cycle
+ */
+export const MAX_UARCH_CYCLE = 1048576n;
 
 /// Constants
 export enum Constant {
     HashSize = 32,
-    TreeLog2WordSize = 5,
-    TreeLog2PageSize = 12,
-    TreeLog2RootSize = 64,
+    HashTreeLog2WordSize = 5,
+    HashTreeLog2PageSize = 12,
+    HashTreeLog2RootSize = 64,
 }
 
-/// Physical memory addresses
-export const PmaConstant = {
+/// Physical memory addresses (address ranges)
+export const ArConstant = {
     CmioRxBufferStart: 0x60000000n,
     CmioRxBufferLog2Size: 21,
     CmioTxBufferStart: 0x60800000n,
     CmioTxBufferLog2Size: 21,
+    ShadowRevertRootHashStart: 0xfe0n,
     RamStart: 0x80000000n,
+    ShadowStateStart: 0x0n,
+    ShadowStateLength: 0x8000n,
+    ShadowTlbStart: 0x1000n,
+    ShadowTlbLength: 0x6000n,
+    PmasStart: 0x10000n,
+    PmasLength: 0x1000n,
 } as const;
 
 /// Error codes returned from the C API
@@ -102,12 +118,15 @@ export enum BreakReason {
     YieldedAutomatically,
     YieldedSoftly,
     ReachedTargetMcycle,
+    ConsoleOutput,
+    ConsoleInput,
 }
 
 /// Reasons for the machine to break from call to cm_run_uarch
 export enum UarchBreakReason {
     ReachedTargetCycle,
     UarchHalted,
+    CycleOverflow,
     Failed,
 }
 
@@ -129,9 +148,22 @@ export enum CmioYieldReason {
     InspectState = 1, ///< Input in rx buffer is an inspect state
 }
 
+/// Sharing modes for backing stores
+export enum SharingMode {
+    None = 0, ///< No sharing, all machine changes will be in-memory
+    Config = 1, ///< Share backing stores marked as shared in the machine configuration
+    All = 2, ///< Share all backing stores, all machine changes will be on-disk
+}
+
+/// Hash function types
+export enum HashFunction {
+    Keccak256 = 0, ///< Keccak-256 (recommended for fraud proofs using microarchitecture)
+    Sha256 = 1, ///< SHA-256 (recommended for fraud proofs using zkVMs)
+}
+
 /// Machine x, f, and control and status registers
 export enum Reg {
-    // Processor x registers
+    // Machine x registers
     X0,
     X1,
     X2,
@@ -164,7 +196,7 @@ export enum Reg {
     X29,
     X30,
     X31,
-    // Processor f registers
+    // Machine f registers
     F0,
     F1,
     F2,
@@ -197,7 +229,7 @@ export enum Reg {
     F29,
     F30,
     F31,
-    // Processor CSRs
+    // Machine CSRs
     Pc,
     Fcsr,
     Mvendorid,
@@ -297,26 +329,34 @@ export interface CartesiMachine {
     create(
         config: MachineConfig,
         runtimeConfig?: MachineRuntimeConfig,
+        dir?: string,
     ): CartesiMachine;
-    load(dir: string, runtimeConfig?: MachineRuntimeConfig): CartesiMachine;
+    load(
+        dir: string,
+        runtimeConfig?: MachineRuntimeConfig,
+        sharing?: SharingMode,
+    ): CartesiMachine;
     cloneEmpty(): CartesiMachine;
-    store(dir: string): CartesiMachine;
+    store(dir: string, sharing?: SharingMode): CartesiMachine;
+    cloneStored(fromDir: string, toDir: string): void;
+    removeStored(dir: string): void;
     destroy(): void;
     getDefaultConfig(): MachineConfig;
     setRuntimeConfig(runtimeConfig: MachineRuntimeConfig): void;
     getRuntimeConfig(): MachineRuntimeConfig;
-    replaceMemoryRange(
-        start: bigint,
-        length: bigint,
-        shared: boolean,
-        imageFilename?: string,
-    ): void;
+    replaceMemoryRange(rangeConfig: MemoryRangeConfig): void;
     getInitialConfig(): MachineConfig;
-    getMemoryRanges(): MemoryRangeDescription[];
+    getAddressRanges(): AddressRangeDescription[];
     getRegAddress(reg: Reg): bigint;
     getRootHash(): Buffer;
-    getProof(address: bigint, log2Size: number): Proof;
+    getNodeHash(address: bigint, log2Size: number): Buffer;
+    getProof(
+        address: bigint,
+        log2TargetSize: number,
+        log2RootSize?: number,
+    ): Proof;
     readWord(address: bigint): bigint;
+    writeWord(address: bigint, value: bigint): void;
     readReg(reg: Reg): bigint;
     writeReg(reg: Reg, value: bigint): void;
     readMemory(address: bigint, length: bigint): Buffer;
@@ -324,8 +364,21 @@ export interface CartesiMachine {
     readVirtualMemory(address: bigint, length: bigint): Buffer;
     writeVirtualMemory(address: bigint, data: Buffer): void;
     translateVirtualAddress(vaddr: bigint): bigint;
+    readConsoleOutput(maxLength?: bigint): Buffer;
+    writeConsoleInput(data: Buffer): bigint;
     run(mcycleEnd?: bigint): BreakReason;
+    collectMcycleRootHashes(
+        mcycleEnd: bigint,
+        mcyclePeriod: bigint,
+        mcyclePhase?: bigint,
+        log2BundleMcycleCount?: number,
+        previousBackTree?: unknown,
+    ): McycleRootHashes;
     runUarch(uarchCycleEnd: bigint): UarchBreakReason;
+    collectUarchCycleRootHashes(
+        mcycleEnd: bigint,
+        log2BundleUarchCycleCount?: number,
+    ): UarchCycleRootHashes;
     resetUarch(): void;
     receiveCmioRequest(): {
         cmd: CmioYieldCommand;
@@ -357,8 +410,8 @@ export interface CartesiMachine {
         log: AccessLog,
         rootHashAfter: Buffer,
     ): void;
-    verifyMerkleTree(): boolean;
-    verifyDirtyPageMaps(): boolean;
+    verifyHashTree(): boolean;
+    getHashTreeStats(clear?: boolean): HashTreeStats;
 }
 
 export function empty(): CartesiMachine {
@@ -368,15 +421,21 @@ export function empty(): CartesiMachine {
 export function create(
     config: MachineConfig,
     runtimeConfig?: MachineRuntimeConfig,
+    dir?: string,
 ): CartesiMachine {
-    return NodeCartesiMachine.createNew(config, runtimeConfig);
+    return NodeCartesiMachine.createNew(config, runtimeConfig, dir);
 }
 
 export function load(
     dir: string,
     runtimeConfig?: MachineRuntimeConfig,
+    sharing?: SharingMode,
 ): CartesiMachine {
-    return NodeCartesiMachine.loadNew(dir, runtimeConfig);
+    return NodeCartesiMachine.loadNew(dir, runtimeConfig, sharing);
+}
+
+export function getVersion(): bigint {
+    return NodeCartesiMachine.getVersion();
 }
 
 export function getLastError(): string {
@@ -389,6 +448,26 @@ export function getDefaultConfig(): MachineConfig {
 
 export function getRegAddress(reg: Reg): bigint {
     return NodeCartesiMachine.getRegAddress(reg);
+}
+
+export function cloneStored(fromDir: string, toDir: string): void {
+    NodeCartesiMachine.cloneStored(fromDir, toDir);
+}
+
+export function removeStored(dir: string): void {
+    NodeCartesiMachine.removeStored(dir);
+}
+
+export function getHash(hashFunction: HashFunction, data: Buffer): Buffer {
+    return NodeCartesiMachine.getHash(hashFunction, data);
+}
+
+export function getConcatHash(
+    hashFunction: HashFunction,
+    left: Buffer,
+    right: Buffer,
+): Buffer {
+    return NodeCartesiMachine.getConcatHash(hashFunction, left, right);
 }
 
 export function verifyStep(

--- a/packages/bindings/cm/src/node/cartesi-machine.ts
+++ b/packages/bindings/cm/src/node/cartesi-machine.ts
@@ -4,6 +4,7 @@ import type {
     CartesiMachine,
     CmioYieldCommand,
     CmioYieldReason,
+    HashFunction,
     Reg,
     UarchBreakReason,
 } from "../cartesi-machine.js";
@@ -12,14 +13,19 @@ import {
     ErrorCode,
     MachineError,
     MAX_MCYCLE,
+    SharingMode,
 } from "../cartesi-machine.js";
 import type {
     AccessLog,
     AccessLogType,
+    AddressRangeDescription,
+    HashTreeStats,
     MachineConfig,
     MachineRuntimeConfig,
-    MemoryRangeDescription,
+    McycleRootHashes,
+    MemoryRangeConfig,
     Proof,
+    UarchCycleRootHashes,
 } from "../types.js";
 import { loadLibrary } from "./lib-loader.js";
 
@@ -36,6 +42,9 @@ koffi.opaque("cm_machine");
 // -----------------------------------------------------------------------------
 // Function signatures
 // -----------------------------------------------------------------------------
+
+/// Returns the machine emulator semantic version at runtime
+const cm_get_version = lib.func("uint64_t cm_get_version()");
 
 /// Returns the error message set by the very last C API call
 const cm_get_last_error_message = lib.func(
@@ -70,26 +79,38 @@ const cm_delete = lib.func("void cm_delete(cm_machine* m)");
 
 /// Creates a new machine instance from configuration
 const cm_create = lib.func(
-    "int cm_create(cm_machine* m, const char* config, const char* runtime_config)",
+    "int cm_create(cm_machine* m, const char* config, const char* runtime_config, const char* dir)",
 );
 
 /// Combines cm_new() and cm_create() for convenience
 const cm_create_new = lib.func(
-    "int cm_create_new(const char* config, const char* runtime_config, _Out_ cm_machine** new_m)",
+    "int cm_create_new(const char* config, const char* runtime_config, const char* dir, _Out_ cm_machine** new_m)",
 );
 
 /// Loads a new machine instance from a previously stored directory
 const cm_load = lib.func(
-    "int cm_load(cm_machine* m, const char* dir, const char* runtime_config)",
+    "int cm_load(cm_machine* m, const char* dir, const char* runtime_config, int sharing)",
 );
 
 /// Combines cm_new() and cm_load() for convenience
 const cm_load_new = lib.func(
-    "int cm_load_new(const char* dir, const char* runtime_config, _Out_ cm_machine** new_m)",
+    "int cm_load_new(const char* dir, const char* runtime_config, int sharing, _Out_ cm_machine** new_m)",
 );
 
 /// Stores a machine instance to a directory, serializing its entire state
-const cm_store = lib.func("int cm_store(const cm_machine* m, const char* dir)");
+const cm_store = lib.func(
+    "int cm_store(const cm_machine* m, const char* dir, int sharing)",
+);
+
+/// Clones a machine stored from source directory to destination directory
+const cm_clone_stored = lib.func(
+    "int cm_clone_stored(const cm_machine* m, const char* from_dir, const char* to_dir)",
+);
+
+/// Removes all files and the directory of a previously stored machine
+const cm_remove_stored = lib.func(
+    "int cm_remove_stored(const cm_machine* m, const char* dir)",
+);
 
 /// Destroy a machine instance and remove it from the object
 const cm_destroy = lib.func("int cm_destroy(cm_machine* m)");
@@ -106,7 +127,7 @@ const cm_get_runtime_config = lib.func(
 
 /// Replaces a memory range
 const cm_replace_memory_range = lib.func(
-    "int cm_replace_memory_range(cm_machine* m, uint64_t start, uint64_t length, bool shared, const char* image_filename)",
+    "int cm_replace_memory_range(cm_machine* m, const char* range_config)",
 );
 
 /// Returns a JSON object with the machine config used to initialize the machine
@@ -114,24 +135,34 @@ const cm_get_initial_config = lib.func(
     "int cm_get_initial_config(const cm_machine* m, _Out_ const char** config)",
 );
 
-/// Returns a list with all memory ranges in the machine
-const cm_get_memory_ranges = lib.func(
-    "int cm_get_memory_ranges(const cm_machine* m, _Out_ const char** ranges)",
+/// Returns a list with all address ranges in the machine
+const cm_get_address_ranges = lib.func(
+    "int cm_get_address_ranges(const cm_machine* m, _Out_ const char** ranges)",
 );
 
-/// Obtains the root hash of the Merkle tree
+/// Obtains the root hash of the hash tree
 const cm_get_root_hash = lib.func(
     "int cm_get_root_hash(const cm_machine* m, _Out_ uint8_t* hash)",
 );
 
-/// Obtains the proof for a node in the machine state Merkle tree
+/// Obtains the hash of a node in the hash tree
+const cm_get_node_hash = lib.func(
+    "int cm_get_node_hash(const cm_machine* m, uint64_t address, int32_t log2_size, _Out_ uint8_t* hash)",
+);
+
+/// Obtains the proof for a node in the machine state hash tree
 const cm_get_proof = lib.func(
-    "int cm_get_proof(const cm_machine* m, uint64_t address, int32_t log2_size, _Out_ const char** proof)",
+    "int cm_get_proof(const cm_machine* m, uint64_t address, int32_t log2_target_size, int log2_root_size, _Out_ const char** proof)",
 );
 
 /// Reads the value of a word in the machine state, by its physical address
 const cm_read_word = lib.func(
     "int cm_read_word(const cm_machine* m, uint64_t address, _Out_ uint64_t* val)",
+);
+
+/// Writes the value of a word in the machine state, by its physical address
+const cm_write_word = lib.func(
+    "int cm_write_word(cm_machine* m, uint64_t address, uint64_t val)",
 );
 
 /// Reads the value of a register
@@ -144,12 +175,12 @@ const cm_write_reg = lib.func(
     "int cm_write_reg(cm_machine* m, int reg, uint64_t val)",
 );
 
-/// Reads a chunk of data from a machine memory range, by its physical address
+/// Reads a chunk of data, by its target physical address and length
 const cm_read_memory = lib.func(
     "int cm_read_memory(const cm_machine* m, uint64_t address, uint8_t* data, uint64_t length)",
 );
 
-/// Writes a chunk of data to a machine memory range, by its physical address
+/// Writes a chunk of data to machine memory, by its target physical address and length
 const cm_write_memory = lib.func(
     "int cm_write_memory(cm_machine* m, uint64_t address, const uint8_t* data, uint64_t length)",
 );
@@ -169,14 +200,34 @@ const cm_translate_virtual_address = lib.func(
     "int cm_translate_virtual_address(const cm_machine* m, uint64_t vaddr, uint64_t* paddr)",
 );
 
+/// Reads and consumes data from the console output buffer
+const cm_read_console_output = lib.func(
+    "int cm_read_console_output(cm_machine* m, uint8_t* data, uint64_t max_length, _Out_ uint64_t* read_len)",
+);
+
+/// Writes data to the console input buffer
+const cm_write_console_input = lib.func(
+    "int cm_write_console_input(cm_machine* m, const uint8_t* data, uint64_t length, _Out_ uint64_t* written_len)",
+);
+
 /// Runs the machine until CM_REG_MCYCLE reaches mcycle_end, the machine yields, or halts
 const cm_run = lib.func(
     "int cm_run(cm_machine* m, uint64_t mcycle_end, _Out_ int* break_reason)",
 );
 
+/// Collects the root hashes after every mcycle_period machine cycles
+const cm_collect_mcycle_root_hashes = lib.func(
+    "int cm_collect_mcycle_root_hashes(cm_machine* m, uint64_t mcycle_end, uint64_t mcycle_period, uint64_t mcycle_phase, int32_t log2_bundle_mcycle_count, const char* previous_back_tree, _Out_ const char** result)",
+);
+
 /// Runs the machine microarchitecture until CM_REG_UARCH_CYCLE reaches uarch_cycle_end or it halts
 const cm_run_uarch = lib.func(
     "int cm_run_uarch(cm_machine* m, uint64_t uarch_cycle_end, _Out_ int* uarch_break_reason)",
+);
+
+/// Collects the root hashes after every uarch cycle
+const cm_collect_uarch_cycle_root_hashes = lib.func(
+    "int cm_collect_uarch_cycle_root_hashes(cm_machine* m, uint64_t mcycle_end, int32_t log2_bundle_uarch_cycle_count, _Out_ const char** result)",
 );
 
 /// Resets the entire microarchitecture state to pristine values
@@ -214,7 +265,7 @@ const cm_log_send_cmio_response = lib.func(
 
 /// Checks the validity of a step log file
 const cm_verify_step = lib.func(
-    "int cm_verify_step(const cm_machine* m, const uint8_t* root_hash_before, const char* log_filename, uint64_t mcycle_count, const uint8_t* root_hash_after, _Out_ int* break_reason)",
+    "int cm_verify_step(const uint8_t* root_hash_before, const char* log_filename, uint64_t mcycle_count, const uint8_t* root_hash_after, _Out_ int* break_reason)",
 );
 
 /// Checks the validity of a state transition produced by cm_log_step_uarch
@@ -232,14 +283,24 @@ const cm_verify_send_cmio_response = lib.func(
     "int cm_verify_send_cmio_response(const cm_machine* m, uint16_t reason, const uint8_t* data, uint64_t length, const uint8_t* root_hash_before, const char* log, const uint8_t* root_hash_after)",
 );
 
-/// Verifies integrity of Merkle tree against current machine state
-const cm_verify_merkle_tree = lib.func(
-    "int cm_verify_merkle_tree(cm_machine* m, _Out_ bool* result)",
+/// Verifies integrity of hash tree against current machine state
+const cm_verify_hash_tree = lib.func(
+    "int cm_verify_hash_tree(cm_machine* m, _Out_ bool* result)",
 );
 
-/// Verifies integrity of dirty page maps
-const cm_verify_dirty_page_maps = lib.func(
-    "int cm_verify_dirty_page_maps(cm_machine* m, _Out_ bool* result)",
+/// Obtains hash tree statistics
+const cm_get_hash_tree_stats = lib.func(
+    "int cm_get_hash_tree_stats(cm_machine* m, bool clear, _Out_ const char** stats)",
+);
+
+/// Gets the hash of data
+const cm_get_hash = lib.func(
+    "int cm_get_hash(int hash_function, const uint8_t* data, uint64_t length, _Out_ uint8_t* result)",
+);
+
+/// Gets the hash of a concatenation of two hashes
+const cm_get_concat_hash = lib.func(
+    "int cm_get_concat_hash(int hash_function, const uint8_t* left, const uint8_t* right, _Out_ uint8_t* result)",
 );
 
 /// Access log types
@@ -295,11 +356,13 @@ export class NodeCartesiMachine {
     static createNew(
         config: MachineConfig,
         runtimeConfig?: MachineRuntimeConfig,
+        dir?: string,
     ): CartesiMachine {
         const machine = [null];
         const result = cm_create_new(
             JSON.stringify(config),
             runtimeConfig ? JSON.stringify(runtimeConfig) : null,
+            dir || null,
             machine,
         );
         if (result !== ErrorCode.Ok) {
@@ -314,11 +377,13 @@ export class NodeCartesiMachine {
     static loadNew(
         dir: string,
         runtimeConfig?: MachineRuntimeConfig,
+        sharing: SharingMode = SharingMode.None,
     ): CartesiMachine {
         const machine = [null];
         const result = cm_load_new(
             dir,
             runtimeConfig ? JSON.stringify(runtimeConfig) : null,
+            sharing,
             machine,
         );
         if (result !== ErrorCode.Ok) {
@@ -330,6 +395,14 @@ export class NodeCartesiMachine {
     constructor(machine: any) {
         this.machine = machine;
         machineFinalizer.register(this, machine);
+    }
+
+    /**
+     * Gets the machine emulator semantic version, encoded as
+     * (major * 1000000) + (minor * 1000) + patch
+     */
+    static getVersion(): bigint {
+        return BigInt(cm_get_version());
     }
 
     /**
@@ -405,11 +478,13 @@ export class NodeCartesiMachine {
     create(
         config: MachineConfig,
         runtimeConfig?: MachineRuntimeConfig,
+        dir?: string,
     ): CartesiMachine {
         const result = cm_create(
             this.machine,
             JSON.stringify(config),
             runtimeConfig ? JSON.stringify(runtimeConfig) : null,
+            dir || null,
         );
         if (result !== ErrorCode.Ok) {
             throw MachineError.fromCode(result);
@@ -420,11 +495,16 @@ export class NodeCartesiMachine {
     /**
      * Loads a machine instance from a directory
      */
-    load(dir: string, runtimeConfig?: MachineRuntimeConfig): CartesiMachine {
+    load(
+        dir: string,
+        runtimeConfig?: MachineRuntimeConfig,
+        sharing: SharingMode = SharingMode.None,
+    ): CartesiMachine {
         const result = cm_load(
             this.machine,
             dir,
             runtimeConfig ? JSON.stringify(runtimeConfig) : null,
+            sharing,
         );
         if (result !== ErrorCode.Ok) {
             throw MachineError.fromCode(result);
@@ -435,12 +515,52 @@ export class NodeCartesiMachine {
     /**
      * Stores the machine instance to a directory
      */
-    store(dir: string): CartesiMachine {
-        const result = cm_store(this.machine, dir);
+    store(dir: string, sharing: SharingMode = SharingMode.All): CartesiMachine {
+        const result = cm_store(this.machine, dir, sharing);
         if (result !== ErrorCode.Ok) {
             throw MachineError.fromCode(result);
         }
         return this;
+    }
+
+    /**
+     * Clones a stored machine from a source directory to a destination directory
+     */
+    cloneStored(fromDir: string, toDir: string): void {
+        const result = cm_clone_stored(this.machine, fromDir, toDir);
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
+    }
+
+    /**
+     * Clones a stored machine from a source directory to a destination directory
+     */
+    static cloneStored(fromDir: string, toDir: string): void {
+        const result = cm_clone_stored(null, fromDir, toDir);
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
+    }
+
+    /**
+     * Removes all files and the directory of a previously stored machine
+     */
+    removeStored(dir: string): void {
+        const result = cm_remove_stored(this.machine, dir);
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
+    }
+
+    /**
+     * Removes all files and the directory of a previously stored machine
+     */
+    static removeStored(dir: string): void {
+        const result = cm_remove_stored(null, dir);
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
     }
 
     /**
@@ -481,18 +601,10 @@ export class NodeCartesiMachine {
     /**
      * Replaces a memory range
      */
-    replaceMemoryRange(
-        start: bigint,
-        length: bigint,
-        shared: boolean,
-        imageFilename?: string,
-    ): void {
+    replaceMemoryRange(rangeConfig: MemoryRangeConfig): void {
         const result = cm_replace_memory_range(
             this.machine,
-            start,
-            length,
-            shared,
-            imageFilename || null,
+            JSON.stringify(rangeConfig),
         );
         if (result !== ErrorCode.Ok) {
             throw MachineError.fromCode(result);
@@ -512,15 +624,15 @@ export class NodeCartesiMachine {
     }
 
     /**
-     * Gets memory ranges
+     * Gets address ranges
      */
-    getMemoryRanges(): MemoryRangeDescription[] {
+    getAddressRanges(): AddressRangeDescription[] {
         const ranges: [string | null] = [null];
-        const result = cm_get_memory_ranges(this.machine, ranges);
+        const result = cm_get_address_ranges(this.machine, ranges);
         if (result !== ErrorCode.Ok) {
             throw MachineError.fromCode(result);
         }
-        return JSON.parse(ranges[0] as string) as MemoryRangeDescription[];
+        return JSON.parse(ranges[0] as string) as AddressRangeDescription[];
     }
 
     /**
@@ -536,11 +648,33 @@ export class NodeCartesiMachine {
     }
 
     /**
-     * Gets a proof for a node in the Merkle tree
+     * Gets the hash of a node in the hash tree
      */
-    getProof(address: bigint, log2Size: number): Proof {
+    getNodeHash(address: bigint, log2Size: number): Buffer {
+        const hash = Buffer.alloc(Constant.HashSize);
+        const result = cm_get_node_hash(this.machine, address, log2Size, hash);
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
+        return hash;
+    }
+
+    /**
+     * Gets a proof for a node in the hash tree
+     */
+    getProof(
+        address: bigint,
+        log2TargetSize: number,
+        log2RootSize: number = Constant.HashTreeLog2RootSize,
+    ): Proof {
         const proof: [string | null] = [null];
-        const result = cm_get_proof(this.machine, address, log2Size, proof);
+        const result = cm_get_proof(
+            this.machine,
+            address,
+            log2TargetSize,
+            log2RootSize,
+            proof,
+        );
         if (result !== ErrorCode.Ok) {
             throw MachineError.fromCode(result);
         }
@@ -557,6 +691,16 @@ export class NodeCartesiMachine {
             throw MachineError.fromCode(result);
         }
         return value[0];
+    }
+
+    /**
+     * Writes a word to memory
+     */
+    writeWord(address: bigint, value: bigint): void {
+        const result = cm_write_word(this.machine, address, value);
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
     }
 
     /**
@@ -653,6 +797,58 @@ export class NodeCartesiMachine {
     }
 
     /**
+     * Reads and consumes data from the console output buffer.
+     * If maxLength is not provided, reads all available data.
+     */
+    readConsoleOutput(maxLength?: bigint): Buffer {
+        let length = maxLength;
+        if (length === undefined) {
+            // query the available size
+            const available = [0n];
+            const result = cm_read_console_output(
+                this.machine,
+                null,
+                0n,
+                available,
+            );
+            if (result !== ErrorCode.Ok) {
+                throw MachineError.fromCode(result);
+            }
+            length = BigInt(available[0]);
+        }
+        const data = Buffer.alloc(Number(length));
+        const readLen = [0n];
+        const result = cm_read_console_output(
+            this.machine,
+            data,
+            length,
+            readLen,
+        );
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
+        return data.subarray(0, Number(readLen[0]));
+    }
+
+    /**
+     * Writes data to the console input buffer.
+     * Returns the number of bytes actually written.
+     */
+    writeConsoleInput(data: Buffer): bigint {
+        const writtenLen = [0n];
+        const result = cm_write_console_input(
+            this.machine,
+            data,
+            BigInt(data.length),
+            writtenLen,
+        );
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
+        return BigInt(writtenLen[0]);
+    }
+
+    /**
      * Runs the machine
      */
     run(mcycleEnd: bigint = MAX_MCYCLE): BreakReason {
@@ -665,6 +861,33 @@ export class NodeCartesiMachine {
     }
 
     /**
+     * Collects the root hashes after every mcyclePeriod machine cycles until
+     * mcycle reaches mcycleEnd, the machine yields, or halts
+     */
+    collectMcycleRootHashes(
+        mcycleEnd: bigint,
+        mcyclePeriod: bigint,
+        mcyclePhase: bigint = 0n,
+        log2BundleMcycleCount: number = 0,
+        previousBackTree?: unknown,
+    ): McycleRootHashes {
+        const collectResult: [string | null] = [null];
+        const result = cm_collect_mcycle_root_hashes(
+            this.machine,
+            mcycleEnd,
+            mcyclePeriod,
+            mcyclePhase,
+            log2BundleMcycleCount,
+            previousBackTree ? JSON.stringify(previousBackTree) : null,
+            collectResult,
+        );
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
+        return JSON.parse(collectResult[0] as string) as McycleRootHashes;
+    }
+
+    /**
      * Runs the microarchitecture
      */
     runUarch(uarchCycleEnd: bigint): UarchBreakReason {
@@ -674,6 +897,27 @@ export class NodeCartesiMachine {
             throw MachineError.fromCode(result);
         }
         return breakReason[0];
+    }
+
+    /**
+     * Collects the root hashes after every uarch cycle until mcycle reaches
+     * mcycleEnd, the machine yields, or halts
+     */
+    collectUarchCycleRootHashes(
+        mcycleEnd: bigint,
+        log2BundleUarchCycleCount: number = 0,
+    ): UarchCycleRootHashes {
+        const collectResult: [string | null] = [null];
+        const result = cm_collect_uarch_cycle_root_hashes(
+            this.machine,
+            mcycleEnd,
+            log2BundleUarchCycleCount,
+            collectResult,
+        );
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
+        return JSON.parse(collectResult[0] as string) as UarchCycleRootHashes;
     }
 
     /**
@@ -817,19 +1061,12 @@ export class NodeCartesiMachine {
         mcycleCount: bigint,
         rootHashAfter: Buffer,
     ): BreakReason {
-        const breakReason = [0];
-        const result = cm_verify_step(
-            this.machine,
+        return NodeCartesiMachine.verifyStep(
             rootHashBefore,
             logFilename,
             mcycleCount,
             rootHashAfter,
-            breakReason,
         );
-        if (result !== ErrorCode.Ok) {
-            throw MachineError.fromCode(result);
-        }
-        return breakReason[0];
     }
 
     /**
@@ -843,7 +1080,6 @@ export class NodeCartesiMachine {
     ): BreakReason {
         const breakReason = [0];
         const result = cm_verify_step(
-            null,
             rootHashBefore,
             logFilename,
             mcycleCount,
@@ -981,11 +1217,11 @@ export class NodeCartesiMachine {
     }
 
     /**
-     * Verifies Merkle tree integrity
+     * Verifies hash tree integrity
      */
-    verifyMerkleTree(): boolean {
+    verifyHashTree(): boolean {
         const result = [false];
-        const error = cm_verify_merkle_tree(this.machine, result);
+        const error = cm_verify_hash_tree(this.machine, result);
         if (error !== ErrorCode.Ok) {
             throw MachineError.fromCode(error);
         }
@@ -993,14 +1229,47 @@ export class NodeCartesiMachine {
     }
 
     /**
-     * Verifies dirty page maps integrity
+     * Gets hash tree statistics
      */
-    verifyDirtyPageMaps(): boolean {
-        const result = [false];
-        const error = cm_verify_dirty_page_maps(this.machine, result);
-        if (error !== ErrorCode.Ok) {
-            throw MachineError.fromCode(error);
+    getHashTreeStats(clear: boolean = false): HashTreeStats {
+        const stats: [string | null] = [null];
+        const result = cm_get_hash_tree_stats(this.machine, clear, stats);
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
         }
-        return result[0];
+        return JSON.parse(stats[0] as string) as HashTreeStats;
+    }
+
+    /**
+     * Gets the hash of data
+     */
+    static getHash(hashFunction: HashFunction, data: Buffer): Buffer {
+        const hash = Buffer.alloc(Constant.HashSize);
+        const result = cm_get_hash(
+            hashFunction,
+            data,
+            BigInt(data.length),
+            hash,
+        );
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
+        return hash;
+    }
+
+    /**
+     * Gets the hash of a concatenation of two hashes
+     */
+    static getConcatHash(
+        hashFunction: HashFunction,
+        left: Buffer,
+        right: Buffer,
+    ): Buffer {
+        const hash = Buffer.alloc(Constant.HashSize);
+        const result = cm_get_concat_hash(hashFunction, left, right, hash);
+        if (result !== ErrorCode.Ok) {
+            throw MachineError.fromCode(result);
+        }
+        return hash;
     }
 }

--- a/packages/bindings/cm/src/node/remote-cartesi-machine.ts
+++ b/packages/bindings/cm/src/node/remote-cartesi-machine.ts
@@ -1,4 +1,8 @@
-import { ErrorCode, MachineError } from "../cartesi-machine.js";
+import {
+    ErrorCode,
+    MachineError,
+    type SharingMode,
+} from "../cartesi-machine.js";
 import type { CleanupCall } from "../remote-cartesi-machine.js";
 import type { MachineConfig, MachineRuntimeConfig } from "../types.js";
 import { NodeCartesiMachine } from "./cartesi-machine.js";
@@ -271,8 +275,9 @@ export class NodeRemoteCartesiMachine extends NodeCartesiMachine {
     load(
         dir: string,
         runtimeConfig?: MachineRuntimeConfig,
+        sharing?: SharingMode,
     ): NodeRemoteCartesiMachine {
-        super.load(dir, runtimeConfig);
+        super.load(dir, runtimeConfig, sharing);
         return this;
     }
 
@@ -284,13 +289,14 @@ export class NodeRemoteCartesiMachine extends NodeCartesiMachine {
     create(
         config: MachineConfig,
         runtimeConfig?: MachineRuntimeConfig,
+        dir?: string,
     ): NodeRemoteCartesiMachine {
-        super.create(config, runtimeConfig);
+        super.create(config, runtimeConfig, dir);
         return this;
     }
 
-    store(dir: string): NodeRemoteCartesiMachine {
-        super.store(dir);
+    store(dir: string, sharing?: SharingMode): NodeRemoteCartesiMachine {
+        super.store(dir, sharing);
         return this;
     }
 }

--- a/packages/bindings/cm/src/remote-cartesi-machine.ts
+++ b/packages/bindings/cm/src/remote-cartesi-machine.ts
@@ -1,4 +1,4 @@
-import type { CartesiMachine } from "./cartesi-machine.js";
+import type { CartesiMachine, SharingMode } from "./cartesi-machine.js";
 import { NodeRemoteCartesiMachine } from "./node/remote-cartesi-machine.js";
 import type { MachineConfig, MachineRuntimeConfig } from "./types.js";
 
@@ -33,13 +33,15 @@ export interface RemoteCartesiMachine extends CartesiMachine {
     load(
         dir: string,
         runtimeConfig?: MachineRuntimeConfig,
+        sharing?: SharingMode,
     ): RemoteCartesiMachine;
     cloneEmpty(): RemoteCartesiMachine;
     create(
         config: MachineConfig,
         runtimeConfig?: MachineRuntimeConfig,
+        dir?: string,
     ): RemoteCartesiMachine;
-    store(dir: string): RemoteCartesiMachine;
+    store(dir: string, sharing?: SharingMode): RemoteCartesiMachine;
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/bindings/cm/src/types.ts
+++ b/packages/bindings/cm/src/types.ts
@@ -1,6 +1,6 @@
 /**
  * TypeScript type definitions for Cartesi Machine
- * Based on the JSON-RPC schema from jsonrpc-discover.json
+ * Based on the JSON-RPC schema from jsonrpc-discover.json (machine-emulator 0.20)
  */
 
 // Base types
@@ -11,28 +11,70 @@ export type Base64Hash = string; // 32-byte hash encoded in base64 (45 chars)
 // VirtIO Device Types
 export type VirtIODeviceType = "console" | "p9fs" | "net-user" | "net-tuntap";
 
+// Hash function used by the hash tree
+export type HashFunctionType = "keccak256" | "sha256";
+
 // Concurrency Runtime Configuration
 export interface ConcurrencyRuntimeConfig {
-    update_merkle_tree?: UnsignedInteger;
+    update_hash_tree?: UnsignedInteger;
 }
 
-// HTIF Runtime Configuration
-export interface HTIFRuntimeConfig {
-    no_console_putchar?: boolean;
+// Console output destinations
+export type ConsoleOutputDestination =
+    | "to_null"
+    | "to_stdout"
+    | "to_stderr"
+    | "to_fd"
+    | "to_file"
+    | "to_buffer";
+
+// Console input sources
+export type ConsoleInputSource =
+    | "from_null"
+    | "from_stdin"
+    | "from_fd"
+    | "from_file"
+    | "from_buffer";
+
+// Console output flush modes
+export type ConsoleFlushMode = "when_full" | "every_char" | "every_line";
+
+// Console Runtime Configuration
+export interface ConsoleRuntimeConfig {
+    output_destination?: ConsoleOutputDestination;
+    output_flush_mode?: ConsoleFlushMode;
+    output_buffer_size?: UnsignedInteger;
+    output_fd?: number;
+    output_filename?: string;
+    input_source?: ConsoleInputSource;
+    input_buffer_size?: UnsignedInteger;
+    input_fd?: number;
+    input_filename?: string;
+    tty_cols?: number;
+    tty_rows?: number;
 }
 
 // Main Machine Runtime Configuration
 export interface MachineRuntimeConfig {
+    console?: ConsoleRuntimeConfig;
     concurrency?: ConcurrencyRuntimeConfig;
-    htif?: HTIFRuntimeConfig;
-    skip_root_hash_check?: boolean;
-    skip_root_hash_store?: boolean;
     skip_version_check?: boolean;
     soft_yield?: boolean;
+    no_reserve?: boolean;
 }
 
-// Processor Configuration
-export interface ProcessorConfig {
+// Backing Store Configuration
+export interface BackingStoreConfig {
+    data_filename?: string; // Backing store for the associated address range
+    dht_filename?: string; // Backing store for the corresponding dense hash-tree
+    dpt_filename?: string; // Backing store for the corresponding dirty-page tree
+    shared?: boolean;
+    create?: boolean;
+    truncate?: boolean;
+}
+
+// Machine Registers Configuration
+export interface RegistersConfig {
     // General purpose registers (x0-x31)
     x0?: UnsignedInteger;
     x1?: UnsignedInteger;
@@ -138,10 +180,16 @@ export interface ProcessorConfig {
     iunrep?: UnsignedInteger;
 }
 
+// Processor Configuration
+export interface ProcessorConfig {
+    registers?: RegistersConfig;
+    backing_store?: BackingStoreConfig;
+}
+
 // RAM Configuration
 export interface RAMConfig {
     length: UnsignedInteger; // Required
-    image_filename?: string;
+    backing_store?: BackingStoreConfig;
 }
 
 // Device Tree Blob Configuration
@@ -149,19 +197,19 @@ export interface DTBConfig {
     bootargs?: string;
     init?: string;
     entrypoint?: string;
-    image_filename?: string;
+    backing_store?: BackingStoreConfig;
 }
 
 // Memory Range Configuration
 export interface MemoryRangeConfig {
     start?: UnsignedInteger;
     length?: UnsignedInteger;
-    image_filename?: string;
-    shared?: boolean;
+    read_only?: boolean;
+    backing_store?: BackingStoreConfig;
 }
 
-// Memory Range Description
-export interface MemoryRangeDescription {
+// Address Range Description
+export interface AddressRangeDescription {
     start?: UnsignedInteger;
     length?: UnsignedInteger;
     description?: string;
@@ -219,33 +267,8 @@ export interface AccessLog {
 // Flash Drive Configurations (array of memory ranges)
 export type FlashDriveConfigs = MemoryRangeConfig[];
 
-// TLB Configuration
-export interface TLBConfig {
-    image_filename?: string;
-}
-
-// CLINT Configuration
-export interface CLINTConfig {
-    mtimecmp?: UnsignedInteger;
-}
-
-// PLIC Configuration
-export interface PLICConfig {
-    girqpend?: UnsignedInteger;
-    girqsrvd?: UnsignedInteger;
-}
-
-// HTIF Configuration
-export interface HTIFConfig {
-    fromhost?: UnsignedInteger;
-    tohost?: UnsignedInteger;
-    console_getchar?: boolean;
-    yield_manual?: boolean;
-    yield_automatic?: boolean;
-}
-
-// Microarchitecture Processor Configuration
-export interface UarchProcessorConfig {
+// Microarchitecture Registers Configuration
+export interface UarchRegistersConfig {
     // General purpose registers (x0-x31)
     x0?: UnsignedInteger;
     x1?: UnsignedInteger;
@@ -286,10 +309,16 @@ export interface UarchProcessorConfig {
     halt_flag?: boolean;
 }
 
+// Microarchitecture Processor Configuration
+export interface UarchProcessorConfig {
+    registers?: UarchRegistersConfig;
+    backing_store?: BackingStoreConfig;
+}
+
 // Microarchitecture RAM Configuration
 export interface UarchRAMConfig {
     length?: UnsignedInteger;
-    image_filename?: string;
+    backing_store?: BackingStoreConfig;
 }
 
 // Microarchitecture Configuration
@@ -300,14 +329,28 @@ export interface UarchConfig {
 
 // CMIO Buffer Configuration
 export interface CmioBufferConfig {
-    image_filename?: string;
-    shared?: boolean;
+    backing_store?: BackingStoreConfig;
 }
 
 // CMIO Configuration
 export interface CmioConfig {
     rx_buffer?: CmioBufferConfig;
     tx_buffer?: CmioBufferConfig;
+}
+
+// PMAs Configuration
+export interface PMAsConfig {
+    backing_store?: BackingStoreConfig;
+}
+
+// Hash Tree Configuration
+export interface HashTreeConfig {
+    shared?: boolean;
+    create?: boolean;
+    sht_filename?: string; // Backing storage for sparse hash-tree
+    phtc_filename?: string; // Backing storage for page hash-tree cache
+    phtc_size?: UnsignedInteger;
+    hash_function?: HashFunctionType;
 }
 
 // VirtIO Host Forwarding
@@ -337,11 +380,55 @@ export interface MachineConfig {
     ram: RAMConfig; // Required
     dtb?: DTBConfig;
     flash_drive?: FlashDriveConfigs;
-    tlb?: TLBConfig;
-    clint?: CLINTConfig;
-    plic?: PLICConfig;
-    htif?: HTIFConfig;
-    uarch?: UarchConfig;
-    cmio?: CmioConfig;
     virtio?: VirtIOConfigs;
+    cmio?: CmioConfig;
+    pmas?: PMAsConfig;
+    uarch?: UarchConfig;
+    hash_tree?: HashTreeConfig;
+}
+
+// Page Hash Tree Cache Statistics
+export interface PageHashTreeCacheStats {
+    page_hits?: UnsignedInteger;
+    page_misses?: UnsignedInteger;
+    word_hits?: UnsignedInteger;
+    word_misses?: UnsignedInteger;
+    page_changes?: UnsignedInteger;
+    inner_page_hashes?: UnsignedInteger;
+    pristine_pages?: UnsignedInteger;
+    non_pristine_pages?: UnsignedInteger;
+}
+
+// Hash Tree Statistics
+export interface HashTreeStats {
+    phtc?: PageHashTreeCacheStats;
+    sparse_node_hashes?: UnsignedInteger;
+    dense_node_hashes?: UnsignedInteger[];
+}
+
+// Interpreter break reason (JSON string representation)
+export type InterpreterBreakReason =
+    | "failed"
+    | "halted"
+    | "yielded_manually"
+    | "yielded_automatically"
+    | "yielded_softly"
+    | "reached_target_mcycle"
+    | "console_output"
+    | "console_input";
+
+// Result of collectMcycleRootHashes
+export interface McycleRootHashes {
+    hashes: Base64Hash[];
+    mcycle_phase: UnsignedInteger;
+    break_reason: InterpreterBreakReason;
+    back_tree?: unknown;
+    console_io_error?: string;
+}
+
+// Result of collectUarchCycleRootHashes
+export interface UarchCycleRootHashes {
+    hashes: Base64Hash[];
+    reset_indices: UnsignedInteger[];
+    break_reason: InterpreterBreakReason;
 }

--- a/packages/bindings/cm/test/cartesi-machine.test.ts
+++ b/packages/bindings/cm/test/cartesi-machine.test.ts
@@ -9,6 +9,7 @@ import {
     ErrorCode,
     getDefaultConfig,
     getLastError,
+    getVersion,
     load,
     Reg,
 } from "../src/cartesi-machine";
@@ -56,6 +57,12 @@ describe("CartesiMachine", () => {
             const error = getLastError();
             expect(typeof error).toBe("string");
         });
+
+        it("should get emulator version", () => {
+            const version = getVersion();
+            // version 0.20.0 is encoded as 20000
+            expect(version).toBeGreaterThanOrEqual(20000n);
+        });
     });
 
     describe("Machine Lifecycle", () => {
@@ -68,8 +75,8 @@ describe("CartesiMachine", () => {
             expect(() => config).not.toThrow();
         });
 
-        it("should get memory ranges", () => {
-            const ranges = machine.getMemoryRanges();
+        it("should get address ranges", () => {
+            const ranges = machine.getAddressRanges();
             expect(() => ranges).not.toThrow();
         });
 
@@ -181,29 +188,38 @@ describe("CartesiMachine", () => {
         });
     });
 
-    describe("Merkle Tree Operations", () => {
+    describe("Hash Tree Operations", () => {
         it("should get root hash", () => {
             const rootHash = machine.getRootHash();
             expect(rootHash).toBeInstanceOf(Buffer);
             expect(rootHash.length).toBe(Constant.HashSize);
         });
 
+        it("should get node hash", () => {
+            const address = 0x80000000n;
+            const log2Size = Constant.HashTreeLog2PageSize;
+
+            const nodeHash = machine.getNodeHash(address, log2Size);
+            expect(nodeHash).toBeInstanceOf(Buffer);
+            expect(nodeHash.length).toBe(Constant.HashSize);
+        });
+
         it("should get proof for memory address", () => {
             const address = 0x80000000n;
-            const log2Size = Constant.TreeLog2WordSize;
+            const log2Size = Constant.HashTreeLog2WordSize;
 
             const proof = machine.getProof(address, log2Size);
             expect(() => proof).not.toThrow();
         });
 
-        it("should verify Merkle tree integrity", () => {
-            const isIntegrityValid = machine.verifyMerkleTree();
+        it("should verify hash tree integrity", () => {
+            const isIntegrityValid = machine.verifyHashTree();
             expect(typeof isIntegrityValid).toBe("boolean");
         });
 
-        it("should verify dirty page maps", () => {
-            const areDirtyMapsValid = machine.verifyDirtyPageMaps();
-            expect(typeof areDirtyMapsValid).toBe("boolean");
+        it("should get hash tree statistics", () => {
+            const stats = machine.getHashTreeStats();
+            expect(typeof stats).toBe("object");
         });
     });
 
@@ -337,9 +353,9 @@ describe("CartesiMachine", () => {
     describe("Constants and Enums", () => {
         it("should have correct constant values", () => {
             expect(Constant.HashSize).toBe(32);
-            expect(Constant.TreeLog2WordSize).toBe(5);
-            expect(Constant.TreeLog2PageSize).toBe(12);
-            expect(Constant.TreeLog2RootSize).toBe(64);
+            expect(Constant.HashTreeLog2WordSize).toBe(5);
+            expect(Constant.HashTreeLog2PageSize).toBe(12);
+            expect(Constant.HashTreeLog2RootSize).toBe(64);
         });
 
         it("should have correct error codes", () => {


### PR DESCRIPTION
## Summary

This PR upgrades the Cartesi Machine TypeScript binding from version 0.19.0 to 0.20.0, implementing breaking changes that align with the upstream C API. The upgrade introduces significant improvements to machine configuration, state management, and hash tree operations.

## Key Changes

### Configuration & State Management
- **Backing Store Configuration**: Replaced `image_filename` and `shared` parameters with a comprehensive `backing_store` object supporting `data_filename`, `dht_filename`, `dpt_filename`, `shared`, `create`, and `truncate` properties
- **Console Configuration**: Added new `ConsoleRuntimeConfig` interface with support for configurable input/output destinations, flush modes, and buffer management
- **Sharing Modes**: Introduced `SharingMode` enum (None, Config, All) to control whether machine state is in-memory or on-disk
- **Directory-based Machine Creation**: Added optional `dir` parameter to `create()` and `load()` methods for on-disk machine instances

### Machine Lifecycle Operations
- `store()` now accepts optional `sharing` parameter to control how state changes are persisted
- Added `cloneStored()` method to clone a stored machine from source to destination directory
- Added `removeStored()` method to remove a stored machine instance

### Memory & Hash Tree Operations
- **Memory Operations**: Added `writeWord()` method for writing 64-bit words to memory
- **Hash Tree Improvements**: 
  - Renamed `verifyMerkleTree()` to `verifyHashTree()`
  - Renamed `getMemoryRanges()` to `getAddressRanges()`
  - Updated `getProof()` signature with `log2TargetSize` and optional `log2RootSize` parameters
  - Added `getNodeHash()` method to obtain hash of a specific node
  - Added `getHashTreeStats()` method for hash tree statistics
- **Root Hash Collection**: Added `collectMcycleRootHashes()` and `collectUarchCycleRootHashes()` methods for periodic hash collection during execution

### Console I/O
- Added `readConsoleOutput()` method to read and consume data from console output buffer
- Added `writeConsoleInput()` method to write data to console input buffer

### API Documentation Updates
- Updated JSON-RPC schema version to 0.6.0
- Updated all documentation and examples to reflect new configuration structure
- Updated type definitions to match machine-emulator 0.20 API

### Internal Changes
- Updated C API function signatures to match new emulator interface
- Added `getVersion()` function to retrieve emulator semantic version at runtime
- Removed deprecated `verify_dirty_page_maps` and `verify_merkle_tree` methods
- Updated register and constant naming for clarity (e.g., `PmaConstant` → `ArConstant`)

## Breaking Changes

This is a **breaking change** release. Users will need to:
1. Update machine configurations to use `backing_store` objects instead of `image_filename`
2. Update method calls to use new parameter names and signatures
3. Update any code using removed methods like `verifyMerkleTree()` and `getMemoryRanges()`
4. Update to machine-emulator 0.20.0 or later

All changes are documented in the included changeset file.

https://claude.ai/code/session_01BRyUC8dGygTFm5ztPu2Kp7