### PR TITLE
Update Cartesi Machine bindings to v0.21.0

### DIFF
--- a/.changeset/cm-cartesi-machine-0-21.md
+++ b/.changeset/cm-cartesi-machine-0-21.md
@@ -2,7 +2,7 @@
 "@deroll/cm": minor
 ---
 
-Target cartesi-machine 0.21 (currently the v0.21.0-test8 pre-release). Breaking changes follow the emulator's new C API:
+Target cartesi-machine 0.21.0. Breaking changes follow the emulator's new C API:
 
 - `sendCmioResponse` takes an optional trailing revert root hash: required for advance-state responses (defaults to the machine's current root hash, the value the emulator checks for) and refused for other responses. `logSendCmioResponse` also takes it (defaulting to the current root hash), and `verifySendCmioResponse` requires it as its last argument.
 - The verify functions (`verifyStep`, `verifyStepUarch`, `verifyResetUarch`, `verifySendCmioResponse`) no longer take `rootHashAfter`; they return the obtained root hash after the operation as a `Buffer`, for the caller to check.

--- a/.changeset/cm-cartesi-machine-0-21.md
+++ b/.changeset/cm-cartesi-machine-0-21.md
@@ -1,0 +1,15 @@
+---
+"@deroll/cm": minor
+---
+
+Target cartesi-machine 0.21 (currently the v0.21.0-test5 pre-release). Breaking changes follow the emulator's new C API:
+
+- `sendCmioResponse` and `logSendCmioResponse` take a revert root hash (defaults to the machine's current root hash, which is what the emulator requires for advance-state responses); `verifySendCmioResponse` requires it as its first argument.
+- The verify functions (`verifyStep`, `verifyStepUarch`, `verifyResetUarch`, `verifySendCmioResponse`) now return the obtained root hash after the operation as a `Buffer`, and `rootHashAfter` became an optional check.
+- `CmioYieldCommand`/`CmioYieldReason` renamed to `HtifYieldCommand`/`HtifYieldReason` (matching the `CM_CMIO_YIELD_*` → `CM_HTIF_YIELD_*` rename in `cm.h`).
+- `ErrorCode` renumbered: `RegexError` and `SystemError` removed, codes after `UnderflowError` shifted up by 2.
+- `BreakReason` gained `McycleOverflow`; `UarchBreakReason` members renamed to `ReachedTargetUarchCycle`/`UarchCycleOverflow`.
+- `Reg` gained `Imcyclemax`, shifting device/uarch register values by one; `UarchHaltFlag` renamed to `UarchHalt`.
+- New machine methods: `readRevertRootHash`, `writeRevertRootHash`, `getAddressName`.
+- Config types: `nvram` machine config, `label` on memory ranges, `dpt_filename` backing store, richer `AddressRangeDescription` attributes, uarch `halt` register (formerly `halt_flag`), and new constants (`PmaDriverId`, HTIF device/yield constants, rollup limits).
+- The native addon now builds against the renamed `cm.h`/`cm-jsonrpc.h` headers and requires an installed cartesi-machine 0.21.x distribution.

--- a/.changeset/cm-cartesi-machine-0-21.md
+++ b/.changeset/cm-cartesi-machine-0-21.md
@@ -2,14 +2,15 @@
 "@deroll/cm": minor
 ---
 
-Target cartesi-machine 0.21 (currently the v0.21.0-test7 pre-release). Breaking changes follow the emulator's new C API:
+Target cartesi-machine 0.21 (currently the v0.21.0-test8 pre-release). Breaking changes follow the emulator's new C API:
 
-- `sendCmioResponse` and `logSendCmioResponse` take a revert root hash (defaults to the machine's current root hash, which is what the emulator requires for advance-state responses); `verifySendCmioResponse` requires it as its first argument.
-- The verify functions (`verifyStep`, `verifyStepUarch`, `verifyResetUarch`, `verifySendCmioResponse`) now return the obtained root hash after the operation as a `Buffer`, and `rootHashAfter` became an optional check.
+- `sendCmioResponse` takes an optional trailing revert root hash: required for advance-state responses (defaults to the machine's current root hash, the value the emulator checks for) and refused for other responses. `logSendCmioResponse` also takes it (defaulting to the current root hash), and `verifySendCmioResponse` requires it as its last argument.
+- The verify functions (`verifyStep`, `verifyStepUarch`, `verifyResetUarch`, `verifySendCmioResponse`) no longer take `rootHashAfter`; they return the obtained root hash after the operation as a `Buffer`, for the caller to check.
 - `CmioYieldCommand`/`CmioYieldReason` renamed to `HtifYieldCommand`/`HtifYieldReason` (matching the `CM_CMIO_YIELD_*` → `CM_HTIF_YIELD_*` rename in `cm.h`).
 - `ErrorCode` renumbered: `RegexError` and `SystemError` removed, codes after `UnderflowError` shifted up by 2.
 - `BreakReason` gained `McycleOverflow`; `UarchBreakReason` members renamed to `ReachedTargetUarchCycle`/`UarchCycleOverflow`.
 - `Reg` gained `Imcyclemax`, shifting device/uarch register values by one; `UarchHaltFlag` renamed to `UarchHalt`.
-- New machine methods: `readRevertRootHash`, `writeRevertRootHash`, `getAddressName`, `isJsonrpcMachine`, `syncStored`.
+- New machine methods: `readRevertRootHash`, `writeRevertRootHash`, `getAddressName`, `isJsonrpcMachine`, `renameStored`, `syncStored`.
+- Machine config restructured: `clint`, `plic`, and `htif` moved into `processor.registers`, `iflags_X/Y/H` collapsed into an `iflags` object, `HTIFConfig` now holds the `ihalt`/`iconsole`/`iyield` registers, and uarch RAM lost its `length` field.
 - Config types: `nvram` machine config, `label` on memory ranges, `dpt_filename` backing store, richer `AddressRangeDescription` attributes, uarch `halt` register (formerly `halt_flag`), and new constants (`PmaDriverId`, HTIF device/yield constants, rollup limits).
 - The native addon now builds against the renamed `cm.h`/`cm-jsonrpc.h` headers and requires an installed cartesi-machine 0.21.x distribution.

--- a/.changeset/cm-cartesi-machine-0-21.md
+++ b/.changeset/cm-cartesi-machine-0-21.md
@@ -2,7 +2,7 @@
 "@deroll/cm": minor
 ---
 
-Target cartesi-machine 0.21 (currently the v0.21.0-test5 pre-release). Breaking changes follow the emulator's new C API:
+Target cartesi-machine 0.21 (currently the v0.21.0-test7 pre-release). Breaking changes follow the emulator's new C API:
 
 - `sendCmioResponse` and `logSendCmioResponse` take a revert root hash (defaults to the machine's current root hash, which is what the emulator requires for advance-state responses); `verifySendCmioResponse` requires it as its first argument.
 - The verify functions (`verifyStep`, `verifyStepUarch`, `verifyResetUarch`, `verifySendCmioResponse`) now return the obtained root hash after the operation as a `Buffer`, and `rootHashAfter` became an optional check.
@@ -10,6 +10,6 @@ Target cartesi-machine 0.21 (currently the v0.21.0-test5 pre-release). Breaking 
 - `ErrorCode` renumbered: `RegexError` and `SystemError` removed, codes after `UnderflowError` shifted up by 2.
 - `BreakReason` gained `McycleOverflow`; `UarchBreakReason` members renamed to `ReachedTargetUarchCycle`/`UarchCycleOverflow`.
 - `Reg` gained `Imcyclemax`, shifting device/uarch register values by one; `UarchHaltFlag` renamed to `UarchHalt`.
-- New machine methods: `readRevertRootHash`, `writeRevertRootHash`, `getAddressName`.
+- New machine methods: `readRevertRootHash`, `writeRevertRootHash`, `getAddressName`, `isJsonrpcMachine`, `syncStored`.
 - Config types: `nvram` machine config, `label` on memory ranges, `dpt_filename` backing store, richer `AddressRangeDescription` attributes, uarch `halt` register (formerly `halt_flag`), and new constants (`PmaDriverId`, HTIF device/yield constants, rollup limits).
 - The native addon now builds against the renamed `cm.h`/`cm-jsonrpc.h` headers and requires an installed cartesi-machine 0.21.x distribution.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ concurrency:
 # machine-guest-tools submodule (its Makefile LINUX_HEADERS_* variables).
 # CARTESI_MACHINE_VERSION: emulator distribution cm's addon links against.
 env:
-    LINUX_IMAGE_VERSION: v0.20.0
-    LINUX_VERSION: 6.5.13-ctsi-1
+    LINUX_IMAGE_VERSION: v0.21.0
+    LINUX_VERSION: 6.5.13-ctsi-2
     CARTESI_MACHINE_VERSION: 0.21.0
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
     LINUX_IMAGE_VERSION: v0.20.0
     LINUX_VERSION: 6.5.13-ctsi-1
-    CARTESI_MACHINE_VERSION: 0.20.0
+    CARTESI_MACHINE_VERSION: 0.21.0-test5
 
 jobs:
     build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
     LINUX_IMAGE_VERSION: v0.20.0
     LINUX_VERSION: 6.5.13-ctsi-1
-    CARTESI_MACHINE_VERSION: 0.21.0-test8
+    CARTESI_MACHINE_VERSION: 0.21.0
 
 jobs:
     build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
     LINUX_IMAGE_VERSION: v0.20.0
     LINUX_VERSION: 6.5.13-ctsi-1
-    CARTESI_MACHINE_VERSION: 0.21.0-test5
+    CARTESI_MACHINE_VERSION: 0.21.0-test7
 
 jobs:
     build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
     LINUX_IMAGE_VERSION: v0.20.0
     LINUX_VERSION: 6.5.13-ctsi-1
-    CARTESI_MACHINE_VERSION: 0.21.0-test7
+    CARTESI_MACHINE_VERSION: 0.21.0-test8
 
 jobs:
     build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 # machine-guest-tools submodule (its Makefile LINUX_HEADERS_* variables).
 # CARTESI_MACHINE_VERSION: emulator distribution cm's addon links against.
 env:
-    LINUX_IMAGE_VERSION: v0.20.0
-    LINUX_VERSION: 6.5.13-ctsi-1
+    LINUX_IMAGE_VERSION: v0.21.0
+    LINUX_VERSION: 6.5.13-ctsi-2
     CARTESI_MACHINE_VERSION: 0.21.0
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 env:
     LINUX_IMAGE_VERSION: v0.20.0
     LINUX_VERSION: 6.5.13-ctsi-1
-    CARTESI_MACHINE_VERSION: 0.21.0-test7
+    CARTESI_MACHINE_VERSION: 0.21.0-test8
 
 jobs:
     # Build native prebuilds only when the owning package is actually about to
@@ -93,7 +93,7 @@ jobs:
             - name: Install cartesi-machine emulator (macos)
               if: runner.os == 'macOS'
               # No homebrew formula exists yet for the 0.21 series (the binding
-              # currently targets the v0.21.0-test7 pre-release). This step
+              # currently targets the v0.21.0-test8 pre-release). This step
               # fails on purpose until cartesi/homebrew-tap ships one — update
               # the branch below (or simplify to a plain
               # `brew install cartesi/tap/cartesi-machine-emulator`) when it
@@ -194,7 +194,7 @@ jobs:
             - name: Install cartesi-machine emulator (macos)
               if: runner.os == 'macOS'
               # No homebrew formula exists yet for the 0.21 series (the binding
-              # currently targets the v0.21.0-test7 pre-release). This step
+              # currently targets the v0.21.0-test8 pre-release). This step
               # fails on purpose until cartesi/homebrew-tap ships one — update
               # the branch below (or simplify to a plain
               # `brew install cartesi/tap/cartesi-machine-emulator`) when it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 env:
     LINUX_IMAGE_VERSION: v0.20.0
     LINUX_VERSION: 6.5.13-ctsi-1
-    CARTESI_MACHINE_VERSION: 0.20.0
+    CARTESI_MACHINE_VERSION: 0.21.0-test5
 
 jobs:
     # Build native prebuilds only when the owning package is actually about to
@@ -92,13 +92,15 @@ jobs:
                   sudo apt-get update && sudo apt-get install -y /tmp/machine-emulator.deb
             - name: Install cartesi-machine emulator (macos)
               if: runner.os == 'macOS'
-              # The 0.20.0 formula is still under review (cartesi/homebrew-tap
-              # branch feature/emulator-0.20.0); the tap's main branch ships
-              # 0.19.0. Once it merges, simplify to a plain
-              # `brew install cartesi/tap/cartesi-machine-emulator`.
+              # No homebrew formula exists yet for the 0.21 series (the binding
+              # currently targets the v0.21.0-test5 pre-release). This step
+              # fails on purpose until cartesi/homebrew-tap ships one — update
+              # the branch below (or simplify to a plain
+              # `brew install cartesi/tap/cartesi-machine-emulator`) when it
+              # lands.
               run: |
                   brew tap cartesi/tap
-                  git -C "$(brew --repository cartesi/tap)" fetch origin feature/emulator-0.20.0
+                  git -C "$(brew --repository cartesi/tap)" fetch origin feature/emulator-0.21.0
                   git -C "$(brew --repository cartesi/tap)" checkout FETCH_HEAD
                   brew install --build-from-source cartesi/tap/cartesi-machine-emulator
             # bun (not npm) — the workspace uses bun's `catalog:` protocol, which
@@ -191,13 +193,15 @@ jobs:
                   sudo apt-get update && sudo apt-get install -y /tmp/machine-emulator.deb
             - name: Install cartesi-machine emulator (macos)
               if: runner.os == 'macOS'
-              # The 0.20.0 formula is still under review (cartesi/homebrew-tap
-              # branch feature/emulator-0.20.0); the tap's main branch ships
-              # 0.19.0. Once it merges, simplify to a plain
-              # `brew install cartesi/tap/cartesi-machine-emulator`.
+              # No homebrew formula exists yet for the 0.21 series (the binding
+              # currently targets the v0.21.0-test5 pre-release). This step
+              # fails on purpose until cartesi/homebrew-tap ships one — update
+              # the branch below (or simplify to a plain
+              # `brew install cartesi/tap/cartesi-machine-emulator`) when it
+              # lands.
               run: |
                   brew tap cartesi/tap
-                  git -C "$(brew --repository cartesi/tap)" fetch origin feature/emulator-0.20.0
+                  git -C "$(brew --repository cartesi/tap)" fetch origin feature/emulator-0.21.0
                   git -C "$(brew --repository cartesi/tap)" checkout FETCH_HEAD
                   brew install --build-from-source cartesi/tap/cartesi-machine-emulator
             # bun (not npm) — the workspace uses bun's `catalog:` protocol, which

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 env:
     LINUX_IMAGE_VERSION: v0.20.0
     LINUX_VERSION: 6.5.13-ctsi-1
-    CARTESI_MACHINE_VERSION: 0.21.0-test5
+    CARTESI_MACHINE_VERSION: 0.21.0-test7
 
 jobs:
     # Build native prebuilds only when the owning package is actually about to
@@ -93,7 +93,7 @@ jobs:
             - name: Install cartesi-machine emulator (macos)
               if: runner.os == 'macOS'
               # No homebrew formula exists yet for the 0.21 series (the binding
-              # currently targets the v0.21.0-test5 pre-release). This step
+              # currently targets the v0.21.0-test7 pre-release). This step
               # fails on purpose until cartesi/homebrew-tap ships one — update
               # the branch below (or simplify to a plain
               # `brew install cartesi/tap/cartesi-machine-emulator`) when it
@@ -194,7 +194,7 @@ jobs:
             - name: Install cartesi-machine emulator (macos)
               if: runner.os == 'macOS'
               # No homebrew formula exists yet for the 0.21 series (the binding
-              # currently targets the v0.21.0-test5 pre-release). This step
+              # currently targets the v0.21.0-test7 pre-release). This step
               # fails on purpose until cartesi/homebrew-tap ships one — update
               # the branch below (or simplify to a plain
               # `brew install cartesi/tap/cartesi-machine-emulator`) when it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 env:
     LINUX_IMAGE_VERSION: v0.20.0
     LINUX_VERSION: 6.5.13-ctsi-1
-    CARTESI_MACHINE_VERSION: 0.21.0-test8
+    CARTESI_MACHINE_VERSION: 0.21.0
 
 jobs:
     # Build native prebuilds only when the owning package is actually about to
@@ -92,17 +92,7 @@ jobs:
                   sudo apt-get update && sudo apt-get install -y /tmp/machine-emulator.deb
             - name: Install cartesi-machine emulator (macos)
               if: runner.os == 'macOS'
-              # No homebrew formula exists yet for the 0.21 series (the binding
-              # currently targets the v0.21.0-test8 pre-release). This step
-              # fails on purpose until cartesi/homebrew-tap ships one — update
-              # the branch below (or simplify to a plain
-              # `brew install cartesi/tap/cartesi-machine-emulator`) when it
-              # lands.
-              run: |
-                  brew tap cartesi/tap
-                  git -C "$(brew --repository cartesi/tap)" fetch origin feature/emulator-0.21.0
-                  git -C "$(brew --repository cartesi/tap)" checkout FETCH_HEAD
-                  brew install --build-from-source cartesi/tap/cartesi-machine-emulator
+              run: brew install cartesi/tap/cartesi-machine-emulator
             # bun (not npm) — the workspace uses bun's `catalog:` protocol, which
             # npm can't resolve. Install at the repo root, then prebuild in cmio.
             - run: bun install --frozen-lockfile
@@ -193,17 +183,7 @@ jobs:
                   sudo apt-get update && sudo apt-get install -y /tmp/machine-emulator.deb
             - name: Install cartesi-machine emulator (macos)
               if: runner.os == 'macOS'
-              # No homebrew formula exists yet for the 0.21 series (the binding
-              # currently targets the v0.21.0-test8 pre-release). This step
-              # fails on purpose until cartesi/homebrew-tap ships one — update
-              # the branch below (or simplify to a plain
-              # `brew install cartesi/tap/cartesi-machine-emulator`) when it
-              # lands.
-              run: |
-                  brew tap cartesi/tap
-                  git -C "$(brew --repository cartesi/tap)" fetch origin feature/emulator-0.21.0
-                  git -C "$(brew --repository cartesi/tap)" checkout FETCH_HEAD
-                  brew install --build-from-source cartesi/tap/cartesi-machine-emulator
+              run: brew install cartesi/tap/cartesi-machine-emulator
             # bun (not npm) — the workspace uses bun's `catalog:` protocol, which
             # npm can't resolve. The cm install script compiles the addon here.
             - run: bun install --frozen-lockfile

--- a/apps/docs/pages/cm/api/cartesi-machine.mdx
+++ b/apps/docs/pages/cm/api/cartesi-machine.mdx
@@ -9,6 +9,7 @@ Descriptions for each method are in the following sections.
 export interface CartesiMachine {
     //// Machine Lifecycle
     isEmpty(): boolean;
+    isJsonrpcMachine(): boolean;
     create(
         config: MachineConfig,
         runtimeConfig?: MachineRuntimeConfig,
@@ -23,6 +24,7 @@ export interface CartesiMachine {
     store(dir: string, sharing?: SharingMode): void;
     cloneStored(fromDir: string, toDir: string): void;
     removeStored(dir: string): void;
+    syncStored(dir: string): void;
     destroy(): void;
     
     //// Configuration
@@ -109,6 +111,14 @@ Checks if the machine object is empty (does not hold a machine instance).
 isEmpty(): boolean;
 ```
 
+## isJsonrpcMachine
+
+Checks if the machine object is a remote machine controlled via the JSON-RPC API.
+
+```ts
+isJsonrpcMachine(): boolean;
+```
+
 ## create
 
 Creates a new machine instance from the given configuration and optional runtime configuration. The machine object must be empty. The optional `dir` sets the directory for on-disk backing stores.
@@ -163,6 +173,14 @@ Removes a stored machine directory.
 
 ```ts
 removeStored(dir: string): void;
+```
+
+## syncStored
+
+Flushes all files of a previously stored machine to permanent storage. The expected usage is to sync after the machine using the stored files has been closed.
+
+```ts
+syncStored(dir: string): void;
 ```
 
 ## destroy

--- a/apps/docs/pages/cm/api/cartesi-machine.mdx
+++ b/apps/docs/pages/cm/api/cartesi-machine.mdx
@@ -23,6 +23,7 @@ export interface CartesiMachine {
     cloneEmpty(): CartesiMachine;
     store(dir: string, sharing?: SharingMode): void;
     cloneStored(fromDir: string, toDir: string): void;
+    renameStored(fromDir: string, toDir: string): void;
     removeStored(dir: string): void;
     syncStored(dir: string): void;
     destroy(): void;
@@ -75,16 +76,8 @@ export interface CartesiMachine {
     ): string;
 
     //// Verification
-    verifyStepUarch(
-        rootHashBefore: Buffer,
-        log: AccessLog,
-        rootHashAfter?: Buffer,
-    ): Buffer;
-    verifyResetUarch(
-        rootHashBefore: Buffer,
-        log: AccessLog,
-        rootHashAfter?: Buffer,
-    ): Buffer;
+    verifyStepUarch(rootHashBefore: Buffer, log: AccessLog): Buffer;
+    verifyResetUarch(rootHashBefore: Buffer, log: AccessLog): Buffer;
 
     //// CMIO Operations
     sendCmioResponse(
@@ -165,6 +158,14 @@ Clones a stored machine directory.
 
 ```ts
 cloneStored(fromDir: string, toDir: string): void;
+```
+
+## renameStored
+
+Renames a stored machine directory and makes the rename durable. The source and destination must be on the same filesystem.
+
+```ts
+renameStored(fromDir: string, toDir: string): void;
 ```
 
 ## removeStored
@@ -433,35 +434,26 @@ verifyStep(
     rootHashBefore,
     logFilename,
     mcycleCount,
-    rootHashAfter, // optional; checked against the obtained root hash when given
-); // returns the obtained root hash after the step
+); // returns the obtained root hash after the step, for the caller to check
 ```
 
-Checks the validity of a state transition produced by a microarchitecture step log and returns the root hash obtained after the step. When `rootHashAfter` is given, it is checked against the obtained hash.
+Checks the validity of a state transition produced by a microarchitecture step log and returns the root hash obtained after the step, for the caller to check.
 
 ```ts
-verifyStepUarch(
-    rootHashBefore: Buffer,
-    log: AccessLog,
-    rootHashAfter?: Buffer,
-): Buffer;
+verifyStepUarch(rootHashBefore: Buffer, log: AccessLog): Buffer;
 ```
 
 ## verifyResetUarch
 
-Checks the validity of a state transition produced by a microarchitecture reset log and returns the root hash obtained after the reset.
+Checks the validity of a state transition produced by a microarchitecture reset log and returns the root hash obtained after the reset, for the caller to check.
 
 ```ts
-verifyResetUarch(
-    rootHashBefore: Buffer,
-    log: AccessLog,
-    rootHashAfter?: Buffer,
-): Buffer;
+verifyResetUarch(rootHashBefore: Buffer, log: AccessLog): Buffer;
 ```
 
 ## sendCmioResponse
 
-Sends a cmio response. Should only be called as a response to cmio requests with manual yield command. The revert root hash is the machine root hash to revert to in case the response is eventually rejected; it defaults to the machine's current root hash, which is the value the emulator requires for advance-state responses.
+Sends a cmio response. Should only be called as a response to cmio requests with manual yield command. The revert root hash is the machine root hash to revert to in case the response is eventually rejected. It is required for advance-state responses — where it defaults to the machine's current root hash, the value the emulator checks for — and must be absent for other responses (inspect-state queries and GIO responses).
 
 ```ts
 sendCmioResponse(

--- a/apps/docs/pages/cm/api/cartesi-machine.mdx
+++ b/apps/docs/pages/cm/api/cartesi-machine.mdx
@@ -54,6 +54,8 @@ export interface CartesiMachine {
 
     //// Hash Tree Operations
     getRootHash(): Buffer;
+    readRevertRootHash(): Buffer;
+    writeRevertRootHash(hash: Buffer): void;
     getNodeHash(address: bigint, log2Size: number): Buffer;
     getProof(address: bigint, log2Size: number, log2RootSize?: number): Proof;
     verifyHashTree(): boolean;
@@ -64,30 +66,38 @@ export interface CartesiMachine {
     logStepUarch(logType: AccessLogType): AccessLog;
     logResetUarch(logType: AccessLogType): AccessLog;
     logSendCmioResponse(
-        reason: CmioYieldReason,
+        reason: HtifYieldReason,
         data: Buffer,
         logType: AccessLogType,
+        revertRootHash?: Buffer,
     ): string;
 
     //// Verification
     verifyStepUarch(
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter: Buffer,
-    ): void;
+        rootHashAfter?: Buffer,
+    ): Buffer;
     verifyResetUarch(
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter: Buffer,
-    ): void;
+        rootHashAfter?: Buffer,
+    ): Buffer;
 
     //// CMIO Operations
-    sendCmioResponse(reason: CmioYieldReason, data: Buffer): void;
+    sendCmioResponse(
+        reason: HtifYieldReason,
+        data: Buffer,
+        revertRootHash?: Buffer,
+    ): void;
     receiveCmioRequest(): {
-        cmd: CmioYieldCommand;
-        reason: CmioYieldReason;
+        cmd: HtifYieldCommand;
+        reason: HtifYieldReason;
         data: Buffer;
     };
+
+    //// Address Introspection
+    getAddressName(paddr: bigint): string;
 }
 ```
 
@@ -383,13 +393,14 @@ logResetUarch(logType: AccessLogType): AccessLog;
 
 ## logSendCmioResponse
 
-Sends a cmio response and returns a log of state accesses.
+Sends a cmio response and returns a log of state accesses. The revert root hash is recorded as part of the logged input; it defaults to the machine's current root hash.
 
 ```ts
 logSendCmioResponse(
-    reason: CmioYieldReason,
+    reason: HtifYieldReason,
     data: Buffer,
     logType: AccessLogType,
+    revertRootHash?: Buffer,
 ): string;
 ```
 
@@ -404,38 +415,42 @@ verifyStep(
     rootHashBefore,
     logFilename,
     mcycleCount,
-    rootHashAfter,
-); // returns BreakReason
+    rootHashAfter, // optional; checked against the obtained root hash when given
+); // returns the obtained root hash after the step
 ```
 
-Checks the validity of a state transition produced by a microarchitecture step log.
+Checks the validity of a state transition produced by a microarchitecture step log and returns the root hash obtained after the step. When `rootHashAfter` is given, it is checked against the obtained hash.
 
 ```ts
 verifyStepUarch(
     rootHashBefore: Buffer,
     log: AccessLog,
-    rootHashAfter: Buffer,
-): void;
+    rootHashAfter?: Buffer,
+): Buffer;
 ```
 
 ## verifyResetUarch
 
-Checks the validity of a state transition produced by a microarchitecture reset log.
+Checks the validity of a state transition produced by a microarchitecture reset log and returns the root hash obtained after the reset.
 
 ```ts
 verifyResetUarch(
     rootHashBefore: Buffer,
     log: AccessLog,
-    rootHashAfter: Buffer,
-): void;
+    rootHashAfter?: Buffer,
+): Buffer;
 ```
 
 ## sendCmioResponse
 
-Sends a cmio response. Should only be called as a response to cmio requests with manual yield command.
+Sends a cmio response. Should only be called as a response to cmio requests with manual yield command. The revert root hash is the machine root hash to revert to in case the response is eventually rejected; it defaults to the machine's current root hash, which is the value the emulator requires for advance-state responses.
 
 ```ts
-sendCmioResponse(reason: CmioYieldReason, data: Buffer): void;
+sendCmioResponse(
+    reason: HtifYieldReason,
+    data: Buffer,
+    revertRootHash?: Buffer,
+): void;
 ```
 
 ## receiveCmioRequest
@@ -444,8 +459,25 @@ Receives a cmio request, including the yield command, reason, and data.
 
 ```ts
 receiveCmioRequest(): {
-    cmd: CmioYieldCommand;
-    reason: CmioYieldReason;
+    cmd: HtifYieldCommand;
+    reason: HtifYieldReason;
     data: Buffer;
 };
+```
+
+## readRevertRootHash / writeRevertRootHash
+
+Reads and writes the revert root hash recorded in the shadow state — the root hash verifiers accept for a rejected rollup input.
+
+```ts
+readRevertRootHash(): Buffer;
+writeRevertRootHash(hash: Buffer): void;
+```
+
+## getAddressName
+
+Gets a description of what is at a given target physical address (also available as a module-level function).
+
+```ts
+getAddressName(paddr: bigint): string;
 ```

--- a/apps/docs/pages/cm/index.mdx
+++ b/apps/docs/pages/cm/index.mdx
@@ -1,6 +1,6 @@
 # Cartesi Machine + Node.js
 
-The [Cartesi machine emulator](https://github.com/cartesi/machine-emulator) is a C++ library with a C API. This package binds it to Node.js as a native N-API addon linked against the static libraries of the official emulator distribution (currently [0.21.0-test5](https://github.com/cartesi/machine-emulator/releases/tag/v0.21.0-test5)). Prebuilt platform packages bundle everything — including the `cartesi-jsonrpc-machine` server executable used by [spawn](/cm/api/spawn) — so **no emulator installation is required** for the supported platforms.
+The [Cartesi machine emulator](https://github.com/cartesi/machine-emulator) is a C++ library with a C API. This package binds it to Node.js as a native N-API addon linked against the static libraries of the official emulator distribution (currently [0.21.0-test7](https://github.com/cartesi/machine-emulator/releases/tag/v0.21.0-test7)). Prebuilt platform packages bundle everything — including the `cartesi-jsonrpc-machine` server executable used by [spawn](/cm/api/spawn) — so **no emulator installation is required** for the supported platforms.
 
 It provides a fully typed and ergonomic TypeScript API for the Cartesi Machine C API and the Cartesi Machine JSON-RPC API, which allows you to create, manage, and interact with local or remote Cartesi machines from TypeScript/JavaScript applications.
 

--- a/apps/docs/pages/cm/index.mdx
+++ b/apps/docs/pages/cm/index.mdx
@@ -1,6 +1,6 @@
 # Cartesi Machine + Node.js
 
-The [Cartesi machine emulator](https://github.com/cartesi/machine-emulator) is a C++ library with a C API. This package binds it to Node.js as a native N-API addon linked against the static libraries of the official emulator distribution (currently [0.20.0](https://github.com/cartesi/machine-emulator/releases/tag/v0.20.0)). Prebuilt platform packages bundle everything — including the `cartesi-jsonrpc-machine` server executable used by [spawn](/cm/api/spawn) — so **no emulator installation is required** for the supported platforms.
+The [Cartesi machine emulator](https://github.com/cartesi/machine-emulator) is a C++ library with a C API. This package binds it to Node.js as a native N-API addon linked against the static libraries of the official emulator distribution (currently [0.21.0-test5](https://github.com/cartesi/machine-emulator/releases/tag/v0.21.0-test5)). Prebuilt platform packages bundle everything — including the `cartesi-jsonrpc-machine` server executable used by [spawn](/cm/api/spawn) — so **no emulator installation is required** for the supported platforms.
 
 It provides a fully typed and ergonomic TypeScript API for the Cartesi Machine C API and the Cartesi Machine JSON-RPC API, which allows you to create, manage, and interact with local or remote Cartesi machines from TypeScript/JavaScript applications.
 

--- a/apps/docs/pages/cm/index.mdx
+++ b/apps/docs/pages/cm/index.mdx
@@ -1,6 +1,6 @@
 # Cartesi Machine + Node.js
 
-The [Cartesi machine emulator](https://github.com/cartesi/machine-emulator) is a C++ library with a C API. This package binds it to Node.js as a native N-API addon linked against the static libraries of the official emulator distribution (currently [0.21.0-test7](https://github.com/cartesi/machine-emulator/releases/tag/v0.21.0-test7)). Prebuilt platform packages bundle everything — including the `cartesi-jsonrpc-machine` server executable used by [spawn](/cm/api/spawn) — so **no emulator installation is required** for the supported platforms.
+The [Cartesi machine emulator](https://github.com/cartesi/machine-emulator) is a C++ library with a C API. This package binds it to Node.js as a native N-API addon linked against the static libraries of the official emulator distribution (currently [0.21.0-test8](https://github.com/cartesi/machine-emulator/releases/tag/v0.21.0-test8)). Prebuilt platform packages bundle everything — including the `cartesi-jsonrpc-machine` server executable used by [spawn](/cm/api/spawn) — so **no emulator installation is required** for the supported platforms.
 
 It provides a fully typed and ergonomic TypeScript API for the Cartesi Machine C API and the Cartesi Machine JSON-RPC API, which allows you to create, manage, and interact with local or remote Cartesi machines from TypeScript/JavaScript applications.
 

--- a/apps/docs/pages/cm/index.mdx
+++ b/apps/docs/pages/cm/index.mdx
@@ -1,6 +1,6 @@
 # Cartesi Machine + Node.js
 
-The [Cartesi machine emulator](https://github.com/cartesi/machine-emulator) is a C++ library with a C API. This package binds it to Node.js as a native N-API addon linked against the static libraries of the official emulator distribution (currently [0.21.0-test8](https://github.com/cartesi/machine-emulator/releases/tag/v0.21.0-test8)). Prebuilt platform packages bundle everything — including the `cartesi-jsonrpc-machine` server executable used by [spawn](/cm/api/spawn) — so **no emulator installation is required** for the supported platforms.
+The [Cartesi machine emulator](https://github.com/cartesi/machine-emulator) is a C++ library with a C API. This package binds it to Node.js as a native N-API addon linked against the static libraries of the official emulator distribution (currently [0.21.0](https://github.com/cartesi/machine-emulator/releases/tag/v0.21.0)). Prebuilt platform packages bundle everything — including the `cartesi-jsonrpc-machine` server executable used by [spawn](/cm/api/spawn) — so **no emulator installation is required** for the supported platforms.
 
 It provides a fully typed and ergonomic TypeScript API for the Cartesi Machine C API and the Cartesi Machine JSON-RPC API, which allows you to create, manage, and interact with local or remote Cartesi machines from TypeScript/JavaScript applications.
 

--- a/apps/docs/pages/cm/local.mdx
+++ b/apps/docs/pages/cm/local.mdx
@@ -15,7 +15,7 @@ function empty(): CartesiMachine;
 ```
 
 The following sections will show step by step how to create and run a very simple local machine.
-It uses the Linux kernel [linux.bin](https://github.com/cartesi/machine-linux-image/releases/download/v0.20.0/linux-6.5.13-ctsi-1-v0.20.0.bin) and a pre-built [rootfs.ext2](https://github.com/cartesi/machine-guest-tools/releases/download/v0.17.1/rootfs-tools.ext2) file as the root filesystem.
+It uses the Linux kernel [linux.bin](https://github.com/cartesi/machine-linux-image/releases/download/v0.21.0/linux-6.5.13-ctsi-2-v0.21.0.bin) and a pre-built [rootfs.ext2](https://github.com/cartesi/machine-guest-tools/releases/download/v0.17.1/rootfs-tools.ext2) file as the root filesystem.
 
 ## Creating a machine
 

--- a/apps/docs/pages/cm/troubleshooting.mdx
+++ b/apps/docs/pages/cm/troubleshooting.mdx
@@ -12,7 +12,7 @@ If neither is found, loading fails with `@deroll/cm: no native binding available
 To compile from source you need:
 
 - a C++ compiler and the usual node-gyp toolchain;
-- an installed cartesi-machine emulator **0.20.x** distribution, which provides the C API headers and the static `libcartesi.a` the addon links against: the `machine-emulator` `.deb` from the [official releases](https://github.com/cartesi/machine-emulator/releases) on Debian/Ubuntu, or `brew install cartesi/tap/cartesi-machine-emulator` on macOS. If installed in a non-standard location, set `CARTESI_INC` / `CARTESI_LIB`.
+- an installed cartesi-machine emulator **0.21.x** distribution, which provides the C API headers and the static `libcartesi.a` the addon links against: the `machine-emulator` `.deb` from the [official releases](https://github.com/cartesi/machine-emulator/releases) on Debian/Ubuntu, or `brew install cartesi/tap/cartesi-machine-emulator` on macOS. If installed in a non-standard location, set `CARTESI_INC` / `CARTESI_LIB`.
 
 ## Error spawning server
 

--- a/packages/bindings/cm/README.md
+++ b/packages/bindings/cm/README.md
@@ -15,7 +15,7 @@ The `optionalDependencies` are injected at publish time (`scripts/inject-platfor
 On platforms without a prebuilt package, the install script compiles the addon from source, which requires:
 
 - a C++ compiler and the usual node-gyp toolchain;
-- an installed cartesi-machine emulator **0.20.x** distribution providing the C API headers and static libraries: the `machine-emulator` `.deb` from the [official releases](https://github.com/cartesi/machine-emulator/releases) on Debian/Ubuntu, or `brew install cartesi/tap/cartesi-machine-emulator` on macOS. Non-standard locations can be pointed at with the `CARTESI_INC` / `CARTESI_LIB` environment variables.
+- an installed cartesi-machine emulator **0.21.x** distribution providing the C API headers and static libraries: the `machine-emulator` `.deb` from the [official releases](https://github.com/cartesi/machine-emulator/releases) on Debian/Ubuntu, or `brew install cartesi/tap/cartesi-machine-emulator` on macOS. Non-standard locations can be pointed at with the `CARTESI_INC` / `CARTESI_LIB` environment variables.
 
 When no usable emulator installation is found, the install prints a warning and **skips** the native build instead of failing — type-only consumers and workspace siblings (docs, explorer) stay installable anywhere; loading the binding without it fails at require() time with a clear error.
 

--- a/packages/bindings/cm/examples/error-handling-example.ts
+++ b/packages/bindings/cm/examples/error-handling-example.ts
@@ -84,9 +84,6 @@ async function demonstrateErrorHandling() {
                     `   Is it an invalid argument? ${error.code === ErrorCode.InvalidArgument}`,
                 );
                 console.log(
-                    `   Is it a system error? ${error.code === ErrorCode.SystemError}`,
-                );
-                console.log(
                     `   Is it a runtime error? ${error.code === ErrorCode.RuntimeError}`,
                 );
 
@@ -94,11 +91,6 @@ async function demonstrateErrorHandling() {
                 switch (error.code) {
                     case ErrorCode.InvalidArgument:
                         console.log("   → This is an invalid argument error");
-                        break;
-                    case ErrorCode.SystemError:
-                        console.log(
-                            "   → This is a system error (likely file not found)",
-                        );
                         break;
                     case ErrorCode.RuntimeError:
                         console.log("   → This is a runtime error");

--- a/packages/bindings/cm/jsonrpc-discover.json
+++ b/packages/bindings/cm/jsonrpc-discover.json
@@ -2,7 +2,7 @@
     "openrpc": "1.0.0-rc1",
     "info": {
         "title": "Remote Cartesi Machine",
-        "version": "0.6.0",
+        "version": "0.7.0",
         "description": "API for controlling a remote Cartesi Machine server",
         "license": {
             "name": "MIT"
@@ -55,6 +55,18 @@
             }
         },
         {
+            "name": "emancipate",
+            "summary": "Breaks the server out of its parent process group, making it the leader of its own process group",
+            "params": [],
+            "result": {
+                "name": "status",
+                "description": "True when operation succeeded",
+                "schema": {
+                    "type": "boolean"
+                }
+            }
+        },
+        {
             "name": "get_version",
             "summary": "Returns the server version",
             "params": [],
@@ -67,7 +79,7 @@
             }
         },
         {
-            "name": "is_empty",
+            "name": "machine.is_empty",
             "summary": "Checks if server has no machine instance",
             "params": [],
             "result": {
@@ -134,6 +146,7 @@
                 {
                     "name": "directory",
                     "description": "Directory to create an on-disk machine instance",
+                    "required": false,
                     "schema": {
                         "type": "string"
                     }
@@ -256,11 +269,40 @@
         },
         {
             "name": "machine.remove_stored",
-            "summary": "Removes a stored machine instance from a directory",
+            "summary": "Removes a stored machine instance from a directory and makes the removal durable",
             "params": [
                 {
                     "name": "dir",
                     "description": "Directory to stored machine instance",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "result": {
+                "name": "status",
+                "description": "True when operation succeeded",
+                "schema": {
+                    "type": "boolean"
+                }
+            }
+        },
+        {
+            "name": "machine.rename_stored",
+            "summary": "Renames a stored machine and makes the rename durable",
+            "params": [
+                {
+                    "name": "from_dir",
+                    "description": "Source directory",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "name": "to_dir",
+                    "description": "Destination directory, which must not exist",
                     "required": true,
                     "schema": {
                         "type": "string"
@@ -355,10 +397,17 @@
                 },
                 {
                     "name": "previous_partial_bundle",
-                    "description": "Partial bundle returned by the previous call",
-                    "required": false,
+                    "description": "Partial bundle returned by the previous call, or null on the first call. The entry must be present either way",
+                    "required": true,
                     "schema": {
-                        "$ref": "#/components/schemas/PartialBundle"
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/PartialBundle"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     }
                 }
             ],
@@ -410,6 +459,14 @@
                     "schema": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     }
+                },
+                {
+                    "name": "revert_uarch_tail",
+                    "description": "Root hashes after each uarch cycle of the period the recorded revert root hash reverts to, the last entry being the revert root hash itself. Required when mcycle_end is greater than the current mcycle, unless the machine starts at a fixed point other than a rejected manual yield",
+                    "required": false,
+                    "schema": {
+                        "$ref": "#/components/schemas/Base64HashArray"
+                    }
                 }
             ],
             "result": {
@@ -426,7 +483,7 @@
             "params": [
                 {
                     "name": "log_type",
-                    "description": "The maximum value of the cycle counter",
+                    "description": "The log type to generate",
                     "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/AccessLogType"
@@ -460,14 +517,6 @@
                     "schema": {
                         "$ref": "#/components/schemas/AccessLog"
                     }
-                },
-                {
-                    "name": "root_hash_after",
-                    "description": "State hash to check against the state after transition",
-                    "required": false,
-                    "schema": {
-                        "$ref": "#/components/schemas/Base64Hash"
-                    }
                 }
             ],
             "result": {
@@ -496,14 +545,6 @@
                     "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/AccessLog"
-                    }
-                },
-                {
-                    "name": "root_hash_after",
-                    "description": "State hash to check against the state after transition",
-                    "required": false,
-                    "schema": {
-                        "$ref": "#/components/schemas/Base64Hash"
                     }
                 }
             ],
@@ -557,6 +598,37 @@
                 "description": "True on success",
                 "schema": {
                     "type": "boolean"
+                }
+            }
+        },
+        {
+            "name": "machine.get_node_hash",
+            "summary": "Obtains the hash of a node in the hash tree",
+            "params": [
+                {
+                    "name": "address",
+                    "description": "Address of node (must be aligned to size)",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                },
+                {
+                    "name": "log2_size",
+                    "description": "Log2 of size of node",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger",
+                        "minimum": 5,
+                        "maximum": 64
+                    }
+                }
+            ],
+            "result": {
+                "name": "hash",
+                "description": "Hash of node",
+                "schema": {
+                    "$ref": "#/components/schemas/Base64Hash"
                 }
             }
         },
@@ -817,6 +889,7 @@
                 {
                     "name": "max_length",
                     "description": "Maximum number of bytes to read",
+                    "required": false,
                     "schema": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     }
@@ -824,26 +897,14 @@
             ],
             "result": {
                 "name": "result",
-                "description": "Console output data or available read length",
+                "description": "Console output data when max_length is given, otherwise the number of bytes available to read",
                 "schema": {
                     "oneOf": [
                         {
-                            "type": "object",
-                            "properties": {
-                                "data": {
-                                    "$ref": "#/components/schemas/Base64String"
-                                }
-                            },
-                            "required": ["data"]
+                            "$ref": "#/components/schemas/Base64String"
                         },
                         {
-                            "type": "object",
-                            "properties": {
-                                "read_len": {
-                                    "$ref": "#/components/schemas/UnsignedInteger"
-                                }
-                            },
-                            "required": ["read_len"]
+                            "$ref": "#/components/schemas/UnsignedInteger"
                         }
                     ]
                 }
@@ -855,7 +916,8 @@
             "params": [
                 {
                     "name": "data",
-                    "description": "Data to write to console input buffer",
+                    "description": "Data to write to console input buffer, or omitted to query the number of bytes available to write",
+                    "required": false,
                     "schema": {
                         "$ref": "#/components/schemas/Base64String"
                     }
@@ -863,7 +925,7 @@
             ],
             "result": {
                 "name": "written_len",
-                "description": "Number of bytes actually written",
+                "description": "Number of bytes actually written when data is given, otherwise the number of bytes available to write",
                 "schema": {
                     "$ref": "#/components/schemas/UnsignedInteger"
                 }
@@ -891,7 +953,7 @@
             }
         },
         {
-            "name": "machine.read_register",
+            "name": "machine.read_reg",
             "summary": "Reads the value of a register",
             "params": [
                 {
@@ -979,7 +1041,7 @@
             "params": [
                 {
                     "name": "log_type",
-                    "description": "The maximum value of the cycle counter",
+                    "description": "The log type to generate",
                     "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/AccessLogType"
@@ -1089,14 +1151,6 @@
             "summary": "Sends cmio response.",
             "params": [
                 {
-                    "name": "revert_root_hash",
-                    "description": "Machine root hash to revert to in case the response is eventually rejected",
-                    "required": true,
-                    "schema": {
-                        "$ref": "#/components/schemas/Base64Hash"
-                    }
-                },
-                {
                     "name": "reason",
                     "description": "Reason for sending response",
                     "required": true,
@@ -1110,6 +1164,14 @@
                     "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/Base64String"
+                    }
+                },
+                {
+                    "name": "revert_root_hash",
+                    "description": "Machine root hash to revert to in case the response is eventually rejected. Required for advance-state responses, and refused for any other reason",
+                    "required": false,
+                    "schema": {
+                        "$ref": "#/components/schemas/Base64Hash"
                     }
                 }
             ],
@@ -1126,14 +1188,6 @@
             "summary": "Sends cmio response and returns an access log",
             "params": [
                 {
-                    "name": "revert_root_hash",
-                    "description": "Machine root hash to revert to in case the response is eventually rejected",
-                    "required": true,
-                    "schema": {
-                        "$ref": "#/components/schemas/Base64Hash"
-                    }
-                },
-                {
                     "name": "reason",
                     "description": "Reason for sending response",
                     "required": true,
@@ -1147,6 +1201,14 @@
                     "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/Base64String"
+                    }
+                },
+                {
+                    "name": "revert_root_hash",
+                    "description": "Machine root hash to revert to in case the response is eventually rejected",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/Base64Hash"
                     }
                 },
                 {
@@ -1170,14 +1232,6 @@
             "name": "machine.verify_send_cmio_response",
             "summary": "Verifies a state transition caused by log_send_cmio_response",
             "params": [
-                {
-                    "name": "revert_root_hash",
-                    "description": "The revert root hash recorded when the log was generated",
-                    "required": true,
-                    "schema": {
-                        "$ref": "#/components/schemas/Base64Hash"
-                    }
-                },
                 {
                     "name": "reason",
                     "description": "Reason for sending response",
@@ -1211,9 +1265,9 @@
                     }
                 },
                 {
-                    "name": "root_hash_after",
-                    "description": "State hash to check against the state after response was sent.",
-                    "required": false,
+                    "name": "revert_root_hash",
+                    "description": "The revert root hash recorded when the log was generated",
+                    "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/Base64Hash"
                     }
@@ -1282,14 +1336,6 @@
                     "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/UnsignedInteger"
-                    }
-                },
-                {
-                    "name": "root_hash_after",
-                    "description": "State hash to check against the state after step",
-                    "required": false,
-                    "schema": {
-                        "$ref": "#/components/schemas/Base64Hash"
                     }
                 }
             ],
@@ -1806,20 +1852,23 @@
                     "iprv": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     },
-                    "iflags_X": {
-                        "$ref": "#/components/schemas/UnsignedInteger"
-                    },
-                    "iflags_Y": {
-                        "$ref": "#/components/schemas/UnsignedInteger"
-                    },
-                    "iflags_H": {
-                        "$ref": "#/components/schemas/UnsignedInteger"
+                    "iflags": {
+                        "$ref": "#/components/schemas/IflagsConfig"
                     },
                     "iunrep": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     },
                     "imcyclemax": {
                         "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "clint": {
+                        "$ref": "#/components/schemas/CLINTConfig"
+                    },
+                    "plic": {
+                        "$ref": "#/components/schemas/PLICConfig"
+                    },
+                    "htif": {
+                        "$ref": "#/components/schemas/HTIFConfig"
                     }
                 }
             },
@@ -1969,6 +2018,21 @@
                     "$ref": "#/components/schemas/MemoryRangeConfig"
                 }
             },
+            "IflagsConfig": {
+                "title": "IflagsConfig",
+                "type": "object",
+                "properties": {
+                    "X": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "Y": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "H": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                }
+            },
             "CLINTConfig": {
                 "title": "CLINTConfig",
                 "type": "object",
@@ -2000,14 +2064,14 @@
                     "tohost": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     },
-                    "console_getchar": {
-                        "type": "boolean"
+                    "ihalt": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
                     },
-                    "yield_manual": {
-                        "type": "boolean"
+                    "iconsole": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
                     },
-                    "yield_automatic": {
-                        "type": "boolean"
+                    "iyield": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
                     }
                 }
             },
@@ -2138,9 +2202,6 @@
                 "title": "UarchRAMConfig",
                 "type": "object",
                 "properties": {
-                    "length": {
-                        "$ref": "#/components/schemas/UnsignedInteger"
-                    },
                     "backing_store": {
                         "$ref": "#/components/schemas/BackingStoreConfig"
                     }
@@ -2161,6 +2222,7 @@
             "CMIOConfig": {
                 "title": "CMIOConfig",
                 "type": "object",
+                "required": ["rx_buffer", "tx_buffer"],
                 "properties": {
                     "rx_buffer": {
                         "$ref": "#/components/schemas/CMIOBufferConfig"
@@ -2229,15 +2291,6 @@
                     "nvram": {
                         "$ref": "#/components/schemas/MemoryRangeConfigs"
                     },
-                    "clint": {
-                        "$ref": "#/components/schemas/CLINTConfig"
-                    },
-                    "plic": {
-                        "$ref": "#/components/schemas/PLICConfig"
-                    },
-                    "htif": {
-                        "$ref": "#/components/schemas/HTIFConfig"
-                    },
                     "virtio": {
                         "$ref": "#/components/schemas/VirtIOConfigs"
                     },
@@ -2292,8 +2345,8 @@
                 "type": "string",
                 "description": "32-byte hash encoded in base64",
                 "contentEncoding": "base64",
-                "minLength": 45,
-                "maxLength": 45
+                "minLength": 44,
+                "maxLength": 44
             },
             "Base64HashArray": {
                 "title": "Base64HashArray",

--- a/packages/bindings/cm/jsonrpc-discover.json
+++ b/packages/bindings/cm/jsonrpc-discover.json
@@ -434,18 +434,18 @@
                 },
                 {
                     "name": "root_hash_after",
-                    "description": "State hash after transition described by access log",
-                    "required": true,
+                    "description": "State hash to check against the state after transition",
+                    "required": false,
                     "schema": {
                         "$ref": "#/components/schemas/Base64Hash"
                     }
                 }
             ],
             "result": {
-                "name": "status",
-                "description": "True when operation succeeded",
+                "name": "hash",
+                "description": "State hash after transition described by access log",
                 "schema": {
-                    "type": "boolean"
+                    "$ref": "#/components/schemas/Base64Hash"
                 }
             }
         },
@@ -471,18 +471,18 @@
                 },
                 {
                     "name": "root_hash_after",
-                    "description": "State hash after transition described by access log",
-                    "required": true,
+                    "description": "State hash to check against the state after transition",
+                    "required": false,
                     "schema": {
                         "$ref": "#/components/schemas/Base64Hash"
                     }
                 }
             ],
             "result": {
-                "name": "status",
-                "description": "True when operation succeeded",
+                "name": "hash",
+                "description": "State hash after transition described by access log",
                 "schema": {
-                    "type": "boolean"
+                    "$ref": "#/components/schemas/Base64Hash"
                 }
             }
         },
@@ -495,6 +495,39 @@
                 "description": "Root hash",
                 "schema": {
                     "$ref": "#/components/schemas/Base64Hash"
+                }
+            }
+        },
+        {
+            "name": "machine.read_revert_root_hash",
+            "summary": "Reads the revert root hash from the shadow state",
+            "params": [],
+            "result": {
+                "name": "hash",
+                "description": "Revert root hash",
+                "schema": {
+                    "$ref": "#/components/schemas/Base64Hash"
+                }
+            }
+        },
+        {
+            "name": "machine.write_revert_root_hash",
+            "summary": "Writes the revert root hash to the shadow state",
+            "params": [
+                {
+                    "name": "hash",
+                    "description": "Revert root hash to store",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/Base64Hash"
+                    }
+                }
+            ],
+            "result": {
+                "name": "result",
+                "description": "True on success",
+                "schema": {
+                    "type": "boolean"
                 }
             }
         },
@@ -957,6 +990,27 @@
             }
         },
         {
+            "name": "machine.get_address_name",
+            "summary": "Returns a description of what is at a given target physical address",
+            "params": [
+                {
+                    "name": "paddr",
+                    "description": "Target physical address of interest",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                }
+            ],
+            "result": {
+                "name": "name",
+                "description": "Description of what is at that address",
+                "schema": {
+                    "type": "string"
+                }
+            }
+        },
+        {
             "name": "machine.verify_hash_tree",
             "summary": "Verifies sanity of hash tree",
             "params": [],
@@ -984,6 +1038,14 @@
             "name": "machine.send_cmio_response",
             "summary": "Sends cmio response.",
             "params": [
+                {
+                    "name": "revert_root_hash",
+                    "description": "Machine root hash to revert to in case the response is eventually rejected",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/Base64Hash"
+                    }
+                },
                 {
                     "name": "reason",
                     "description": "Reason for sending response",
@@ -1013,6 +1075,14 @@
             "name": "machine.log_send_cmio_response",
             "summary": "Sends cmio response and returns an access log",
             "params": [
+                {
+                    "name": "revert_root_hash",
+                    "description": "Machine root hash to revert to in case the response is eventually rejected",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/Base64Hash"
+                    }
+                },
                 {
                     "name": "reason",
                     "description": "Reason for sending response",
@@ -1051,6 +1121,14 @@
             "summary": "Verifies a state transition caused by log_send_cmio_response",
             "params": [
                 {
+                    "name": "revert_root_hash",
+                    "description": "The revert root hash recorded when the log was generated",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/Base64Hash"
+                    }
+                },
+                {
                     "name": "reason",
                     "description": "Reason for sending response",
                     "required": true,
@@ -1084,18 +1162,18 @@
                 },
                 {
                     "name": "root_hash_after",
-                    "description": "State hash after response was sent.",
-                    "required": true,
+                    "description": "State hash to check against the state after response was sent.",
+                    "required": false,
                     "schema": {
                         "$ref": "#/components/schemas/Base64Hash"
                     }
                 }
             ],
             "result": {
-                "name": "status",
-                "description": "True when operation succeeded",
+                "name": "hash",
+                "description": "State hash after response was sent.",
                 "schema": {
-                    "type": "boolean"
+                    "$ref": "#/components/schemas/Base64Hash"
                 }
             }
         },
@@ -1158,18 +1236,18 @@
                 },
                 {
                     "name": "root_hash_after",
-                    "description": "State hash after step",
-                    "required": true,
+                    "description": "State hash to check against the state after step",
+                    "required": false,
                     "schema": {
                         "$ref": "#/components/schemas/Base64Hash"
                     }
                 }
             ],
             "result": {
-                "name": "status",
-                "description": "True when operation succeeded",
+                "name": "hash",
+                "description": "State hash after step",
                 "schema": {
-                    "type": "boolean"
+                    "$ref": "#/components/schemas/Base64Hash"
                 }
             }
         }
@@ -1670,6 +1748,9 @@
                     },
                     "iunrep": {
                         "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "imcyclemax": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
                     }
                 }
             },
@@ -1708,6 +1789,9 @@
                 "title": "MemoryRangeConfig",
                 "type": "object",
                 "properties": {
+                    "label": {
+                        "type": "string"
+                    },
                     "start": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     },
@@ -1730,6 +1814,9 @@
                         "type": "string"
                     },
                     "dht_filename": {
+                        "type": "string"
+                    },
+                    "dpt_filename": {
                         "type": "string"
                     },
                     "shared": {
@@ -1806,8 +1893,8 @@
                     }
                 }
             },
-            "FlashDriveConfigs": {
-                "title": "FlashDriveConfigs",
+            "MemoryRangeConfigs": {
+                "title": "MemoryRangeConfigs",
                 "type": "array",
                 "items": {
                     "$ref": "#/components/schemas/MemoryRangeConfig"
@@ -1973,7 +2060,7 @@
                     "cycle": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     },
-                    "halt_flag": {
+                    "halt": {
                         "$ref": "#/components/schemas/UnsignedInteger"
                     }
                 }
@@ -2068,7 +2155,10 @@
                         "$ref": "#/components/schemas/DTBConfig"
                     },
                     "flash_drive": {
-                        "$ref": "#/components/schemas/FlashDriveConfigs"
+                        "$ref": "#/components/schemas/MemoryRangeConfigs"
+                    },
+                    "nvram": {
+                        "$ref": "#/components/schemas/MemoryRangeConfigs"
                     },
                     "clint": {
                         "$ref": "#/components/schemas/CLINTConfig"
@@ -2111,15 +2201,16 @@
                     "yielded_softly",
                     "reached_target_mcycle",
                     "console_output",
-                    "console_input"
+                    "console_input",
+                    "mcycle_overflow"
                 ]
             },
             "UarchInterpreterBreakReason": {
                 "title": "UarchInterpreterBreakReason",
                 "enum": [
-                    "reached_target_cycle",
+                    "reached_target_uarch_cycle",
                     "uarch_halted",
-                    "cycle_overflow"
+                    "uarch_cycle_overflow"
                 ]
             },
             "Base64String": {
@@ -2387,6 +2478,7 @@
                     "iflags_Y",
                     "iflags_H",
                     "iunrep",
+                    "imcyclemax",
                     "clint_mtimecmp",
                     "plic_girqpend",
                     "plic_girqsrvd",
@@ -2437,7 +2529,7 @@
                     "uarch_x31",
                     "uarch_pc",
                     "uarch_cycle",
-                    "uarch_halt_flag"
+                    "uarch_halt"
                 ]
             },
             "AddressRangeDescription": {
@@ -2452,6 +2544,30 @@
                     },
                     "description": {
                         "type": "string"
+                    },
+                    "is_memory": {
+                        "type": "boolean"
+                    },
+                    "is_device": {
+                        "type": "boolean"
+                    },
+                    "is_readable": {
+                        "type": "boolean"
+                    },
+                    "is_writeable": {
+                        "type": "boolean"
+                    },
+                    "is_executable": {
+                        "type": "boolean"
+                    },
+                    "is_read_idempotent": {
+                        "type": "boolean"
+                    },
+                    "is_write_idempotent": {
+                        "type": "boolean"
+                    },
+                    "driver_id": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
                     }
                 }
             },

--- a/packages/bindings/cm/jsonrpc-discover.json
+++ b/packages/bindings/cm/jsonrpc-discover.json
@@ -276,6 +276,27 @@
             }
         },
         {
+            "name": "machine.sync_stored",
+            "summary": "Flushes a stored machine instance in a directory to permanent storage",
+            "params": [
+                {
+                    "name": "dir",
+                    "description": "Directory to stored machine instance",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "result": {
+                "name": "status",
+                "description": "True when operation succeeded",
+                "schema": {
+                    "type": "boolean"
+                }
+            }
+        },
+        {
             "name": "machine.run",
             "summary": "Runs the emulator until a given cycle",
             "params": [
@@ -309,8 +330,8 @@
                     }
                 },
                 {
-                    "name": "mcycle_period",
-                    "description": "Number of machine cycles between root hashes to collect",
+                    "name": "log2_mcycle_period",
+                    "description": "Log base 2 of the number of machine cycles between root hashes to collect",
                     "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/UnsignedInteger"
@@ -330,6 +351,14 @@
                     "required": true,
                     "schema": {
                         "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                },
+                {
+                    "name": "previous_partial_bundle",
+                    "description": "Partial bundle returned by the previous call",
+                    "required": false,
+                    "schema": {
+                        "$ref": "#/components/schemas/PartialBundle"
                     }
                 }
             ],
@@ -1035,6 +1064,27 @@
             }
         },
         {
+            "name": "machine.receive_cmio_request",
+            "summary": "Receives a cmio request.",
+            "params": [
+                {
+                    "name": "length",
+                    "description": "Maximum data length to return, or zero to return only the available length",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                }
+            ],
+            "result": {
+                "name": "request",
+                "description": "Yield command, reason, available length, and requested data of the cmio request",
+                "schema": {
+                    "$ref": "#/components/schemas/CmioRequest"
+                }
+            }
+        },
+        {
             "name": "machine.send_cmio_response",
             "summary": "Sends cmio response.",
             "params": [
@@ -1268,6 +1318,25 @@
                     },
                     "pid": {
                         "$ref": "#/components/schemas/UnsignedInteger"
+                    }
+                }
+            },
+            "CmioRequest": {
+                "title": "CmioRequest",
+                "type": "object",
+                "required": ["cmd", "reason", "available_length", "data"],
+                "properties": {
+                    "cmd": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "reason": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "available_length": {
+                        "$ref": "#/components/schemas/UnsignedInteger"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/Base64String"
                     }
                 }
             },
@@ -2591,8 +2660,8 @@
                     "break_reason": {
                         "$ref": "#/components/schemas/InterpreterBreakReason"
                     },
-                    "back_tree": {
-                        "$ref": "#/components/schemas/BackMerkleTree"
+                    "partial_bundle": {
+                        "$ref": "#/components/schemas/PartialBundle"
                     },
                     "console_io_error": {
                         "type": "string"
@@ -2607,17 +2676,17 @@
                     "hashes": {
                         "$ref": "#/components/schemas/Base64HashArray"
                     },
-                    "reset_indices": {
+                    "mcycle_hash_offsets": {
                         "$ref": "#/components/schemas/UnsignedIntegerArray"
                     },
                     "break_reason": {
                         "$ref": "#/components/schemas/InterpreterBreakReason"
                     }
                 },
-                "required": ["hashes", "reset_indices", "break_reason"]
+                "required": ["hashes", "mcycle_hash_offsets", "break_reason"]
             },
-            "BackMerkleTree": {
-                "title": "BackMerkleTree",
+            "PartialBundle": {
+                "title": "PartialBundle",
                 "type": "object",
                 "properties": {
                     "log2_max_leaves": {

--- a/packages/bindings/cm/scripts/find-cartesi.cjs
+++ b/packages/bindings/cm/scripts/find-cartesi.cjs
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 // Locates the installed cartesi-machine emulator distribution, which provides
-// the C API headers (machine-c-api.h, jsonrpc-machine-c-api.h), the static
-// libraries (libcartesi.a, libcartesi_jsonrpc.a) and the
-// cartesi-jsonrpc-machine server executable.
+// the C API headers (cm.h, cm-jsonrpc.h), the static libraries (libcartesi.a,
+// libcartesi_jsonrpc.a) and the cartesi-jsonrpc-machine server executable.
 //
 // Usage: node find-cartesi.cjs include|lib|omp
-//   include -> directory containing machine-c-api.h (override: CARTESI_INC)
+//   include -> directory containing cm.h (override: CARTESI_INC)
 //   lib     -> directory containing libcartesi.a (override: CARTESI_LIB)
 //   omp     -> extra OpenMP linker flags for macOS (brew libomp), or nothing
 "use strict";
@@ -46,7 +45,7 @@ switch (kind) {
                     "/usr/include/cartesi-machine",
                     "/opt/local/include/cartesi-machine",
                 ],
-                "machine-c-api.h",
+                "cm.h",
             ),
         );
         break;

--- a/packages/bindings/cm/scripts/install.cjs
+++ b/packages/bindings/cm/scripts/install.cjs
@@ -20,7 +20,7 @@ const { existsSync, readFileSync } = require("node:fs");
 const path = require("node:path");
 
 // emulator version series the binding targets
-const CARTESI_MACHINE_SERIES = "0.20";
+const CARTESI_MACHINE_SERIES = "0.21";
 
 const platformPackage = `@deroll/cm-${process.platform}-${process.arch}`;
 try {
@@ -52,7 +52,7 @@ if (!compiled) {
     const inc = run("include");
     const lib = run("lib");
     if (
-        !existsSync(path.join(inc, "machine-c-api.h")) ||
+        !existsSync(path.join(inc, "cm.h")) ||
         !existsSync(path.join(lib, "libcartesi.a"))
     ) {
         console.warn(
@@ -71,7 +71,7 @@ if (!compiled) {
 
     // The binding targets a specific emulator series; catch mismatched
     // installations (e.g. an older brew formula) before the compiler does.
-    const versionHeader = path.join(inc, "machine-c-version.h");
+    const versionHeader = path.join(inc, "cm-version.h");
     if (existsSync(versionHeader)) {
         const header = readFileSync(versionHeader, "utf8");
         const major = header.match(/#define CM_VERSION_MAJOR (\d+)/)?.[1];

--- a/packages/bindings/cm/src/addon.cc
+++ b/packages/bindings/cm/src/addon.cc
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-// N-API binding for the Cartesi Machine emulator C API (machine-c-api.h and
-// jsonrpc-machine-c-api.h), compiled together with libcartesi from the
+// N-API binding for the Cartesi Machine emulator C API (cm.h and
+// cm-jsonrpc.h), compiled together with libcartesi from the
 // machine-emulator submodule.
 //
 // The whole API is synchronous on purpose: the TypeScript layer drives the
@@ -43,14 +43,14 @@
 #include <napi.h>
 
 extern "C" {
-#include "jsonrpc-machine-c-api.h"
-#include "machine-c-api.h"
+#include "cm-jsonrpc.h"
+#include "cm.h"
 }
 
 namespace {
 
 // The cmio rx/tx buffers are 2^21 bytes long (CM_AR_CMIO_RX_BUFFER_LOG2_SIZE)
-constexpr size_t CMIO_BUFFER_SIZE = static_cast<size_t>(1) << 21;
+constexpr size_t CMIO_BUFFER_SIZE = static_cast<size_t>(CM_AR_CMIO_RX_BUFFER_LENGTH);
 
 void throw_machine_error(Napi::Env env, cm_error code) {
     const char *description = cm_get_last_error_message();
@@ -138,6 +138,15 @@ bool get_hash(Napi::Env env, const Napi::Value &value, const char *name, const c
     return true;
 }
 
+// An optional 32-byte hash argument (null/undefined become "absent").
+bool get_optional_hash(Napi::Env env, const Napi::Value &value, const char *name, const cm_hash **hash) {
+    if (value.IsUndefined() || value.IsNull()) {
+        *hash = nullptr;
+        return true;
+    }
+    return get_hash(env, value, name, hash);
+}
+
 // A required UTF-8 string argument, copied into out.
 bool get_string(Napi::Env env, const Napi::Value &value, const char *name, std::string *out) {
     if (!value.IsString()) {
@@ -200,6 +209,9 @@ private:
     Napi::Value GetInitialConfig(const Napi::CallbackInfo &info);
     Napi::Value GetAddressRanges(const Napi::CallbackInfo &info);
     Napi::Value GetRootHash(const Napi::CallbackInfo &info);
+    Napi::Value ReadRevertRootHash(const Napi::CallbackInfo &info);
+    Napi::Value WriteRevertRootHash(const Napi::CallbackInfo &info);
+    Napi::Value GetAddressName(const Napi::CallbackInfo &info);
     Napi::Value GetProof(const Napi::CallbackInfo &info);
     Napi::Value ReadWord(const Napi::CallbackInfo &info);
     Napi::Value ReadReg(const Napi::CallbackInfo &info);
@@ -407,6 +419,34 @@ Napi::Value Machine::GetRootHash(const Napi::CallbackInfo &info) {
     return Napi::Buffer<uint8_t>::Copy(env, hash, CM_HASH_SIZE);
 }
 
+Napi::Value Machine::ReadRevertRootHash(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+    cm_hash hash{};
+    CHECK_CM(env, cm_read_revert_root_hash(machine_, &hash));
+    return Napi::Buffer<uint8_t>::Copy(env, hash, CM_HASH_SIZE);
+}
+
+Napi::Value Machine::WriteRevertRootHash(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+    const cm_hash *hash = nullptr;
+    if (!get_hash(env, info[0], "hash", &hash)) {
+        return env.Undefined();
+    }
+    CHECK_CM(env, cm_write_revert_root_hash(machine_, hash));
+    return env.Undefined();
+}
+
+Napi::Value Machine::GetAddressName(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+    uint64_t paddr = 0;
+    if (!get_u64(env, info[0], "paddr", &paddr)) {
+        return env.Undefined();
+    }
+    const char *name = nullptr;
+    CHECK_CM(env, cm_get_address_name(machine_, paddr, &name));
+    return Napi::String::New(env, name);
+}
+
 Napi::Value Machine::GetProof(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     uint64_t address = 0;
@@ -567,13 +607,15 @@ Napi::Value Machine::ReceiveCmioRequest(const Napi::CallbackInfo &info) {
 
 Napi::Value Machine::SendCmioResponse(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
+    const cm_hash *revert_root_hash = nullptr;
     int32_t reason = 0;
     const uint8_t *data = nullptr;
     size_t length = 0;
-    if (!get_i32(env, info[0], "reason", &reason) || !get_bytes(env, info[1], "data", &data, &length)) {
+    if (!get_hash(env, info[0], "revertRootHash", &revert_root_hash) || !get_i32(env, info[1], "reason", &reason) ||
+        !get_bytes(env, info[2], "data", &data, &length)) {
         return env.Undefined();
     }
-    CHECK_CM(env, cm_send_cmio_response(machine_, static_cast<uint16_t>(reason), data, length));
+    CHECK_CM(env, cm_send_cmio_response(machine_, revert_root_hash, static_cast<uint16_t>(reason), data, length));
     return env.Undefined();
 }
 
@@ -613,21 +655,25 @@ Napi::Value Machine::LogResetUarch(const Napi::CallbackInfo &info) {
 
 Napi::Value Machine::LogSendCmioResponse(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
+    const cm_hash *revert_root_hash = nullptr;
     int32_t reason = 0;
     const uint8_t *data = nullptr;
     size_t length = 0;
     int32_t log_type = 0;
-    if (!get_i32(env, info[0], "reason", &reason) || !get_bytes(env, info[1], "data", &data, &length) ||
-        !get_i32(env, info[2], "logType", &log_type)) {
+    if (!get_hash(env, info[0], "revertRootHash", &revert_root_hash) || !get_i32(env, info[1], "reason", &reason) ||
+        !get_bytes(env, info[2], "data", &data, &length) || !get_i32(env, info[3], "logType", &log_type)) {
         return env.Undefined();
     }
     const char *log = nullptr;
-    CHECK_CM(env, cm_log_send_cmio_response(machine_, static_cast<uint16_t>(reason), data, length, log_type, &log));
+    CHECK_CM(env, cm_log_send_cmio_response(machine_, revert_root_hash, static_cast<uint16_t>(reason), data, length,
+                      log_type, &log));
     return Napi::String::New(env, log);
 }
 
 // Shared implementation for the instance methods and the module-level
 // functions (which pass m == nullptr).
+// The verify functions check root_hash_after when given (null/undefined skips
+// the check) and return the root hash obtained after the operation.
 Napi::Value verify_step(Napi::Env env, const Napi::CallbackInfo &info, size_t base) {
     const cm_hash *root_hash_before = nullptr;
     std::string log_filename;
@@ -636,13 +682,13 @@ Napi::Value verify_step(Napi::Env env, const Napi::CallbackInfo &info, size_t ba
     if (!get_hash(env, info[base + 0], "rootHashBefore", &root_hash_before) ||
         !get_string(env, info[base + 1], "logFilename", &log_filename) ||
         !get_u64(env, info[base + 2], "mcycleCount", &mcycle_count) ||
-        !get_hash(env, info[base + 3], "rootHashAfter", &root_hash_after)) {
+        !get_optional_hash(env, info[base + 3], "rootHashAfter", &root_hash_after)) {
         return env.Undefined();
     }
-    cm_break_reason break_reason = CM_BREAK_REASON_FAILED;
+    cm_hash obtained_root_hash{};
     CHECK_CM(env,
-        cm_verify_step(root_hash_before, log_filename.c_str(), mcycle_count, root_hash_after, &break_reason));
-    return Napi::Number::New(env, break_reason);
+        cm_verify_step(root_hash_before, log_filename.c_str(), mcycle_count, root_hash_after, &obtained_root_hash));
+    return Napi::Buffer<uint8_t>::Copy(env, obtained_root_hash, CM_HASH_SIZE);
 }
 
 Napi::Value verify_step_uarch(Napi::Env env, cm_machine *m, const Napi::CallbackInfo &info, size_t base) {
@@ -651,11 +697,12 @@ Napi::Value verify_step_uarch(Napi::Env env, cm_machine *m, const Napi::Callback
     const cm_hash *root_hash_after = nullptr;
     if (!get_hash(env, info[base + 0], "rootHashBefore", &root_hash_before) ||
         !get_string(env, info[base + 1], "log", &log) ||
-        !get_hash(env, info[base + 2], "rootHashAfter", &root_hash_after)) {
+        !get_optional_hash(env, info[base + 2], "rootHashAfter", &root_hash_after)) {
         return env.Undefined();
     }
-    CHECK_CM(env, cm_verify_step_uarch(m, root_hash_before, log.c_str(), root_hash_after));
-    return env.Undefined();
+    cm_hash obtained_root_hash{};
+    CHECK_CM(env, cm_verify_step_uarch(m, root_hash_before, log.c_str(), root_hash_after, &obtained_root_hash));
+    return Napi::Buffer<uint8_t>::Copy(env, obtained_root_hash, CM_HASH_SIZE);
 }
 
 Napi::Value verify_reset_uarch(Napi::Env env, cm_machine *m, const Napi::CallbackInfo &info, size_t base) {
@@ -664,29 +711,33 @@ Napi::Value verify_reset_uarch(Napi::Env env, cm_machine *m, const Napi::Callbac
     const cm_hash *root_hash_after = nullptr;
     if (!get_hash(env, info[base + 0], "rootHashBefore", &root_hash_before) ||
         !get_string(env, info[base + 1], "log", &log) ||
-        !get_hash(env, info[base + 2], "rootHashAfter", &root_hash_after)) {
+        !get_optional_hash(env, info[base + 2], "rootHashAfter", &root_hash_after)) {
         return env.Undefined();
     }
-    CHECK_CM(env, cm_verify_reset_uarch(m, root_hash_before, log.c_str(), root_hash_after));
-    return env.Undefined();
+    cm_hash obtained_root_hash{};
+    CHECK_CM(env, cm_verify_reset_uarch(m, root_hash_before, log.c_str(), root_hash_after, &obtained_root_hash));
+    return Napi::Buffer<uint8_t>::Copy(env, obtained_root_hash, CM_HASH_SIZE);
 }
 
 Napi::Value verify_send_cmio_response(Napi::Env env, cm_machine *m, const Napi::CallbackInfo &info, size_t base) {
+    const cm_hash *revert_root_hash = nullptr;
     int32_t reason = 0;
     const uint8_t *data = nullptr;
     size_t length = 0;
     const cm_hash *root_hash_before = nullptr;
     std::string log;
     const cm_hash *root_hash_after = nullptr;
-    if (!get_i32(env, info[base + 0], "reason", &reason) || !get_bytes(env, info[base + 1], "data", &data, &length) ||
-        !get_hash(env, info[base + 2], "rootHashBefore", &root_hash_before) ||
-        !get_string(env, info[base + 3], "log", &log) ||
-        !get_hash(env, info[base + 4], "rootHashAfter", &root_hash_after)) {
+    if (!get_hash(env, info[base + 0], "revertRootHash", &revert_root_hash) ||
+        !get_i32(env, info[base + 1], "reason", &reason) || !get_bytes(env, info[base + 2], "data", &data, &length) ||
+        !get_hash(env, info[base + 3], "rootHashBefore", &root_hash_before) ||
+        !get_string(env, info[base + 4], "log", &log) ||
+        !get_optional_hash(env, info[base + 5], "rootHashAfter", &root_hash_after)) {
         return env.Undefined();
     }
-    CHECK_CM(env, cm_verify_send_cmio_response(m, static_cast<uint16_t>(reason), data, length, root_hash_before,
-                      log.c_str(), root_hash_after));
-    return env.Undefined();
+    cm_hash obtained_root_hash{};
+    CHECK_CM(env, cm_verify_send_cmio_response(m, revert_root_hash, static_cast<uint16_t>(reason), data, length,
+                      root_hash_before, log.c_str(), root_hash_after, &obtained_root_hash));
+    return Napi::Buffer<uint8_t>::Copy(env, obtained_root_hash, CM_HASH_SIZE);
 }
 
 Napi::Value Machine::VerifyStepUarch(const Napi::CallbackInfo &info) {
@@ -871,6 +922,9 @@ Napi::Object Machine::Init(Napi::Env env, Napi::Object exports) {
             InstanceMethod<&Machine::GetInitialConfig>("getInitialConfig"),
             InstanceMethod<&Machine::GetAddressRanges>("getAddressRanges"),
             InstanceMethod<&Machine::GetRootHash>("getRootHash"),
+            InstanceMethod<&Machine::ReadRevertRootHash>("readRevertRootHash"),
+            InstanceMethod<&Machine::WriteRevertRootHash>("writeRevertRootHash"),
+            InstanceMethod<&Machine::GetAddressName>("getAddressName"),
             InstanceMethod<&Machine::GetProof>("getProof"),
             InstanceMethod<&Machine::ReadWord>("readWord"),
             InstanceMethod<&Machine::ReadReg>("readReg"),
@@ -993,6 +1047,17 @@ Napi::Value GetRegAddress(const Napi::CallbackInfo &info) {
     return Napi::BigInt::New(env, val);
 }
 
+Napi::Value GetAddressName(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+    uint64_t paddr = 0;
+    if (!get_u64(env, info[0], "paddr", &paddr)) {
+        return env.Undefined();
+    }
+    const char *name = nullptr;
+    CHECK_CM(env, cm_get_address_name(nullptr, paddr, &name));
+    return Napi::String::New(env, name);
+}
+
 Napi::Value VerifyStep(const Napi::CallbackInfo &info) {
     return verify_step(info.Env(), info, 0);
 }
@@ -1084,6 +1149,7 @@ Napi::Object InitModule(Napi::Env env, Napi::Object exports) {
     exports.Set("machineLoadNew", Napi::Function::New(env, MachineLoadNew));
     exports.Set("getDefaultConfig", Napi::Function::New(env, GetDefaultConfig));
     exports.Set("getRegAddress", Napi::Function::New(env, GetRegAddress));
+    exports.Set("getAddressName", Napi::Function::New(env, GetAddressName));
     exports.Set("verifyStep", Napi::Function::New(env, VerifyStep));
     exports.Set("verifyStepUarch", Napi::Function::New(env, VerifyStepUarch));
     exports.Set("verifyResetUarch", Napi::Function::New(env, VerifyResetUarch));

--- a/packages/bindings/cm/src/addon.cc
+++ b/packages/bindings/cm/src/addon.cc
@@ -239,6 +239,7 @@ private:
     Napi::Value WriteWord(const Napi::CallbackInfo &info);
     Napi::Value GetNodeHash(const Napi::CallbackInfo &info);
     Napi::Value CloneStored(const Napi::CallbackInfo &info);
+    Napi::Value RenameStored(const Napi::CallbackInfo &info);
     Napi::Value RemoveStored(const Napi::CallbackInfo &info);
     Napi::Value SyncStored(const Napi::CallbackInfo &info);
     // cm-jsonrpc.h
@@ -616,15 +617,15 @@ Napi::Value Machine::ReceiveCmioRequest(const Napi::CallbackInfo &info) {
 
 Napi::Value Machine::SendCmioResponse(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
-    const cm_hash *revert_root_hash = nullptr;
     int32_t reason = 0;
     const uint8_t *data = nullptr;
     size_t length = 0;
-    if (!get_hash(env, info[0], "revertRootHash", &revert_root_hash) || !get_i32(env, info[1], "reason", &reason) ||
-        !get_bytes(env, info[2], "data", &data, &length)) {
+    const cm_hash *revert_root_hash = nullptr;
+    if (!get_i32(env, info[0], "reason", &reason) || !get_bytes(env, info[1], "data", &data, &length) ||
+        !get_optional_hash(env, info[2], "revertRootHash", &revert_root_hash)) {
         return env.Undefined();
     }
-    CHECK_CM(env, cm_send_cmio_response(machine_, revert_root_hash, static_cast<uint16_t>(reason), data, length));
+    CHECK_CM(env, cm_send_cmio_response(machine_, static_cast<uint16_t>(reason), data, length, revert_root_hash));
     return env.Undefined();
 }
 
@@ -664,88 +665,79 @@ Napi::Value Machine::LogResetUarch(const Napi::CallbackInfo &info) {
 
 Napi::Value Machine::LogSendCmioResponse(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
-    const cm_hash *revert_root_hash = nullptr;
     int32_t reason = 0;
     const uint8_t *data = nullptr;
     size_t length = 0;
+    const cm_hash *revert_root_hash = nullptr;
     int32_t log_type = 0;
-    if (!get_hash(env, info[0], "revertRootHash", &revert_root_hash) || !get_i32(env, info[1], "reason", &reason) ||
-        !get_bytes(env, info[2], "data", &data, &length) || !get_i32(env, info[3], "logType", &log_type)) {
+    if (!get_i32(env, info[0], "reason", &reason) || !get_bytes(env, info[1], "data", &data, &length) ||
+        !get_hash(env, info[2], "revertRootHash", &revert_root_hash) || !get_i32(env, info[3], "logType", &log_type)) {
         return env.Undefined();
     }
     const char *log = nullptr;
-    CHECK_CM(env, cm_log_send_cmio_response(machine_, revert_root_hash, static_cast<uint16_t>(reason), data, length,
+    CHECK_CM(env, cm_log_send_cmio_response(machine_, static_cast<uint16_t>(reason), data, length, revert_root_hash,
                       log_type, &log));
     return Napi::String::New(env, log);
 }
 
 // Shared implementation for the instance methods and the module-level
 // functions (which pass m == nullptr).
-// The verify functions check root_hash_after when given (null/undefined skips
-// the check) and return the root hash obtained after the operation.
+// The verify functions return the root hash obtained after the operation,
+// for the caller to check.
 Napi::Value verify_step(Napi::Env env, const Napi::CallbackInfo &info, size_t base) {
     const cm_hash *root_hash_before = nullptr;
     std::string log_filename;
     uint64_t mcycle_count = 0;
-    const cm_hash *root_hash_after = nullptr;
     if (!get_hash(env, info[base + 0], "rootHashBefore", &root_hash_before) ||
         !get_string(env, info[base + 1], "logFilename", &log_filename) ||
-        !get_u64(env, info[base + 2], "mcycleCount", &mcycle_count) ||
-        !get_optional_hash(env, info[base + 3], "rootHashAfter", &root_hash_after)) {
+        !get_u64(env, info[base + 2], "mcycleCount", &mcycle_count)) {
         return env.Undefined();
     }
     cm_hash obtained_root_hash{};
-    CHECK_CM(env,
-        cm_verify_step(root_hash_before, log_filename.c_str(), mcycle_count, root_hash_after, &obtained_root_hash));
+    CHECK_CM(env, cm_verify_step(root_hash_before, log_filename.c_str(), mcycle_count, &obtained_root_hash));
     return Napi::Buffer<uint8_t>::Copy(env, obtained_root_hash, CM_HASH_SIZE);
 }
 
 Napi::Value verify_step_uarch(Napi::Env env, cm_machine *m, const Napi::CallbackInfo &info, size_t base) {
     const cm_hash *root_hash_before = nullptr;
     std::string log;
-    const cm_hash *root_hash_after = nullptr;
     if (!get_hash(env, info[base + 0], "rootHashBefore", &root_hash_before) ||
-        !get_string(env, info[base + 1], "log", &log) ||
-        !get_optional_hash(env, info[base + 2], "rootHashAfter", &root_hash_after)) {
+        !get_string(env, info[base + 1], "log", &log)) {
         return env.Undefined();
     }
     cm_hash obtained_root_hash{};
-    CHECK_CM(env, cm_verify_step_uarch(m, root_hash_before, log.c_str(), root_hash_after, &obtained_root_hash));
+    CHECK_CM(env, cm_verify_step_uarch(m, root_hash_before, log.c_str(), &obtained_root_hash));
     return Napi::Buffer<uint8_t>::Copy(env, obtained_root_hash, CM_HASH_SIZE);
 }
 
 Napi::Value verify_reset_uarch(Napi::Env env, cm_machine *m, const Napi::CallbackInfo &info, size_t base) {
     const cm_hash *root_hash_before = nullptr;
     std::string log;
-    const cm_hash *root_hash_after = nullptr;
     if (!get_hash(env, info[base + 0], "rootHashBefore", &root_hash_before) ||
-        !get_string(env, info[base + 1], "log", &log) ||
-        !get_optional_hash(env, info[base + 2], "rootHashAfter", &root_hash_after)) {
+        !get_string(env, info[base + 1], "log", &log)) {
         return env.Undefined();
     }
     cm_hash obtained_root_hash{};
-    CHECK_CM(env, cm_verify_reset_uarch(m, root_hash_before, log.c_str(), root_hash_after, &obtained_root_hash));
+    CHECK_CM(env, cm_verify_reset_uarch(m, root_hash_before, log.c_str(), &obtained_root_hash));
     return Napi::Buffer<uint8_t>::Copy(env, obtained_root_hash, CM_HASH_SIZE);
 }
 
 Napi::Value verify_send_cmio_response(Napi::Env env, cm_machine *m, const Napi::CallbackInfo &info, size_t base) {
-    const cm_hash *revert_root_hash = nullptr;
     int32_t reason = 0;
     const uint8_t *data = nullptr;
     size_t length = 0;
     const cm_hash *root_hash_before = nullptr;
     std::string log;
-    const cm_hash *root_hash_after = nullptr;
-    if (!get_hash(env, info[base + 0], "revertRootHash", &revert_root_hash) ||
-        !get_i32(env, info[base + 1], "reason", &reason) || !get_bytes(env, info[base + 2], "data", &data, &length) ||
-        !get_hash(env, info[base + 3], "rootHashBefore", &root_hash_before) ||
-        !get_string(env, info[base + 4], "log", &log) ||
-        !get_optional_hash(env, info[base + 5], "rootHashAfter", &root_hash_after)) {
+    const cm_hash *revert_root_hash = nullptr;
+    if (!get_i32(env, info[base + 0], "reason", &reason) || !get_bytes(env, info[base + 1], "data", &data, &length) ||
+        !get_hash(env, info[base + 2], "rootHashBefore", &root_hash_before) ||
+        !get_string(env, info[base + 3], "log", &log) ||
+        !get_hash(env, info[base + 4], "revertRootHash", &revert_root_hash)) {
         return env.Undefined();
     }
     cm_hash obtained_root_hash{};
-    CHECK_CM(env, cm_verify_send_cmio_response(m, revert_root_hash, static_cast<uint16_t>(reason), data, length,
-                      root_hash_before, log.c_str(), root_hash_after, &obtained_root_hash));
+    CHECK_CM(env, cm_verify_send_cmio_response(m, static_cast<uint16_t>(reason), data, length, root_hash_before,
+                      log.c_str(), revert_root_hash, &obtained_root_hash));
     return Napi::Buffer<uint8_t>::Copy(env, obtained_root_hash, CM_HASH_SIZE);
 }
 
@@ -807,6 +799,17 @@ Napi::Value Machine::CloneStored(const Napi::CallbackInfo &info) {
         return env.Undefined();
     }
     CHECK_CM(env, cm_clone_stored(machine_, from_dir.c_str(), to_dir.c_str()));
+    return env.Undefined();
+}
+
+Napi::Value Machine::RenameStored(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+    std::string from_dir;
+    std::string to_dir;
+    if (!get_string(env, info[0], "fromDir", &from_dir) || !get_string(env, info[1], "toDir", &to_dir)) {
+        return env.Undefined();
+    }
+    CHECK_CM(env, cm_rename_stored(machine_, from_dir.c_str(), to_dir.c_str()));
     return env.Undefined();
 }
 
@@ -971,6 +974,7 @@ Napi::Object Machine::Init(Napi::Env env, Napi::Object exports) {
             InstanceMethod<&Machine::WriteWord>("writeWord"),
             InstanceMethod<&Machine::GetNodeHash>("getNodeHash"),
             InstanceMethod<&Machine::CloneStored>("cloneStored"),
+            InstanceMethod<&Machine::RenameStored>("renameStored"),
             InstanceMethod<&Machine::RemoveStored>("removeStored"),
             InstanceMethod<&Machine::SyncStored>("syncStored"),
             InstanceMethod<&Machine::JsonrpcFork>("jsonrpcFork"),

--- a/packages/bindings/cm/src/addon.cc
+++ b/packages/bindings/cm/src/addon.cc
@@ -194,8 +194,9 @@ public:
     }
 
 private:
-    // machine-c-api.h
+    // cm.h
     Napi::Value IsEmpty(const Napi::CallbackInfo &info);
+    Napi::Value IsJsonrpcMachine(const Napi::CallbackInfo &info);
     Napi::Value Create(const Napi::CallbackInfo &info);
     Napi::Value Load(const Napi::CallbackInfo &info);
     Napi::Value CloneEmpty(const Napi::CallbackInfo &info);
@@ -239,7 +240,8 @@ private:
     Napi::Value GetNodeHash(const Napi::CallbackInfo &info);
     Napi::Value CloneStored(const Napi::CallbackInfo &info);
     Napi::Value RemoveStored(const Napi::CallbackInfo &info);
-    // jsonrpc-machine-c-api.h
+    Napi::Value SyncStored(const Napi::CallbackInfo &info);
+    // cm-jsonrpc.h
     Napi::Value JsonrpcFork(const Napi::CallbackInfo &info);
     Napi::Value JsonrpcShutdownServer(const Napi::CallbackInfo &info);
     Napi::Value JsonrpcRebindServer(const Napi::CallbackInfo &info);
@@ -292,6 +294,13 @@ Napi::Value Machine::IsEmpty(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     bool yes = false;
     CHECK_CM(env, cm_is_empty(machine_, &yes));
+    return Napi::Boolean::New(env, yes);
+}
+
+Napi::Value Machine::IsJsonrpcMachine(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+    bool yes = false;
+    CHECK_CM(env, cm_is_jsonrpc_machine(machine_, &yes));
     return Napi::Boolean::New(env, yes);
 }
 
@@ -811,6 +820,16 @@ Napi::Value Machine::RemoveStored(const Napi::CallbackInfo &info) {
     return env.Undefined();
 }
 
+Napi::Value Machine::SyncStored(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+    std::string dir;
+    if (!get_string(env, info[0], "dir", &dir)) {
+        return env.Undefined();
+    }
+    CHECK_CM(env, cm_sync_stored(machine_, dir.c_str()));
+    return env.Undefined();
+}
+
 Napi::Value Machine::JsonrpcFork(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     cm_machine *forked_m = nullptr;
@@ -909,6 +928,7 @@ Napi::Object Machine::Init(Napi::Env env, Napi::Object exports) {
     Napi::Function func = DefineClass(env, "Machine",
         {
             InstanceMethod<&Machine::IsEmpty>("isEmpty"),
+            InstanceMethod<&Machine::IsJsonrpcMachine>("isJsonrpcMachine"),
             InstanceMethod<&Machine::Create>("create"),
             InstanceMethod<&Machine::Load>("load"),
             InstanceMethod<&Machine::CloneEmpty>("cloneEmpty"),
@@ -952,6 +972,7 @@ Napi::Object Machine::Init(Napi::Env env, Napi::Object exports) {
             InstanceMethod<&Machine::GetNodeHash>("getNodeHash"),
             InstanceMethod<&Machine::CloneStored>("cloneStored"),
             InstanceMethod<&Machine::RemoveStored>("removeStored"),
+            InstanceMethod<&Machine::SyncStored>("syncStored"),
             InstanceMethod<&Machine::JsonrpcFork>("jsonrpcFork"),
             InstanceMethod<&Machine::JsonrpcShutdownServer>("jsonrpcShutdownServer"),
             InstanceMethod<&Machine::JsonrpcRebindServer>("jsonrpcRebindServer"),

--- a/packages/bindings/cm/src/cartesi-machine.ts
+++ b/packages/bindings/cm/src/cartesi-machine.ts
@@ -352,10 +352,13 @@ export enum Reg {
     Unknown_,
     First_,
     Last_,
+    UarchFirst_,
+    UarchLast_,
 }
 
 export interface CartesiMachine {
     isEmpty(): boolean;
+    isJsonrpcMachine(): boolean;
     create(
         config: MachineConfig,
         runtimeConfig?: MachineRuntimeConfig,
@@ -370,6 +373,7 @@ export interface CartesiMachine {
     store(dir: string, sharing?: SharingMode): CartesiMachine;
     cloneStored(fromDir: string, toDir: string): void;
     removeStored(dir: string): void;
+    syncStored(dir: string): void;
     destroy(): void;
     getDefaultConfig(): MachineConfig;
     setRuntimeConfig(runtimeConfig: MachineRuntimeConfig): void;

--- a/packages/bindings/cm/src/cartesi-machine.ts
+++ b/packages/bindings/cm/src/cartesi-machine.ts
@@ -19,22 +19,65 @@ import type {
  */
 export const MAX_MCYCLE = 0xffffffffffffffffn;
 
+/**
+ * The maximum value for uarch_cycle
+ * ((1 << CM_ROLLUP_LOG2_MAX_UARCH_CYCLES_PER_MCYCLE) - 1)
+ */
+export const MAX_UARCH_CYCLE = (1n << 20n) - 1n;
+
 /// Constants
 export enum Constant {
     HashSize = 32,
     TreeLog2WordSize = 5,
     TreeLog2PageSize = 12,
     TreeLog2RootSize = 64,
+    RollupLog2MaxMcyclesPerAdvanceState = 48,
+    RollupLog2MaxUarchCyclesPerMcycle = 20,
+    RollupLog2MaxOutputCount = 63,
+    RollupLog2MaxAdvanceStatesPerEpoch = 24,
+    FlashDriveMax = 8, ///< Maximum number of flash drives
+    // biome-ignore lint/suspicious/noDuplicateEnumValues: mirrors cm_constant in cm.h
+    NvramMax = 8, ///< Maximum number of NVRAMs
+    MemoryRangeLabelMax = 31, ///< Maximum length of a memory range user label
+    RtcFreqDiv = 8192, ///< mtime increments once per this many mcycle increments
 }
 
 /// Physical memory addresses
 export const PmaConstant = {
     CmioRxBufferStart: 0x60000000n,
     CmioRxBufferLog2Size: 21,
+    CmioRxBufferLength: 0x200000n,
     CmioTxBufferStart: 0x60800000n,
     CmioTxBufferLog2Size: 21,
+    CmioTxBufferLength: 0x200000n,
     RamStart: 0x80000000n,
+    ClintStart: 0x2000000n,
+    ClintLength: 0xc0000n,
+    HtifStart: 0x40008000n,
+    HtifLength: 0x1000n,
+    FirstVirtioStart: 0x40010000n,
+    LastVirtioEnd: 0x40020000n,
+    PlicStart: 0x40100000n,
+    PlicLength: 0x00400000n,
+    DtbStart: 0x7ff00000n,
+    DtbLength: 0x100000n,
 } as const;
+
+/// Driver IDs for PMA entries
+export enum PmaDriverId {
+    Empty = 0,
+    Memory = 1,
+    ShadowState = 2,
+    FlashDrive = 3,
+    Clint = 4,
+    Htif = 5,
+    Plic = 6,
+    CmioRxBuffer = 7,
+    CmioTxBuffer = 8,
+    ShadowUarchState = 9,
+    Virtio = 10,
+    Nvram = 11,
+}
 
 /// Error codes returned from the C API
 export enum ErrorCode {
@@ -48,20 +91,18 @@ export enum ErrorCode {
     RangeError = -7,
     OverflowError = -8,
     UnderflowError = -9,
-    RegexError = -10,
-    SystemError = -11,
-    BadTypeid = -12,
-    BadCast = -13,
-    BadAnyCast = -14,
-    BadOptionalAccess = -15,
-    BadWeakPtr = -16,
-    BadFunctionCall = -17,
-    BadAlloc = -18,
-    BadArrayNewLength = -19,
-    BadException = -20,
-    BadVariantAccess = -21,
-    Exception = -22,
-    Unknown = -23,
+    BadTypeid = -10,
+    BadCast = -11,
+    BadAnyCast = -12,
+    BadOptionalAccess = -13,
+    BadWeakPtr = -14,
+    BadFunctionCall = -15,
+    BadAlloc = -16,
+    BadArrayNewLength = -17,
+    BadException = -18,
+    BadVariantAccess = -19,
+    Exception = -20,
+    Unknown = -21,
 }
 
 /**
@@ -106,13 +147,14 @@ export enum BreakReason {
     ReachedTargetMcycle,
     ConsoleOutput,
     ConsoleInput,
+    McycleOverflow,
 }
 
 /// Reasons for the machine to break from call to cm_run_uarch
 export enum UarchBreakReason {
-    ReachedTargetCycle,
+    ReachedTargetUarchCycle,
     UarchHalted,
-    CycleOverflow,
+    UarchCycleOverflow,
     Failed,
 }
 
@@ -123,14 +165,21 @@ export enum SharingMode {
     All = 2, ///< Machine state fully on-disk
 }
 
-/// Yield device commands
-export enum CmioYieldCommand {
+/// HTIF device identifiers (DEV field of tohost/fromhost)
+export enum HtifDevice {
+    Halt = 0, ///< Halts the machine
+    Console = 1, ///< Console input and output
+    Yield = 2, ///< Yield control back to the host
+}
+
+/// Yield device commands (CM_HTIF_YIELD_CMD_*, formerly CM_CMIO_YIELD_COMMAND_*)
+export enum HtifYieldCommand {
     Automatic,
     Manual,
 }
 
-/// Yield reasons
-export enum CmioYieldReason {
+/// Yield reasons (CM_HTIF_YIELD_*_REASON_*, formerly CM_CMIO_YIELD_*_REASON_*)
+export enum HtifYieldReason {
     AutomaticProgress = 1, ///< Progress is available
     AutomaticTxOutput = 2, ///< Output is available in tx buffer
     AutomaticTxReport = 4, ///< Report is available in tx buffer
@@ -244,6 +293,7 @@ export enum Reg {
     IflagsY,
     IflagsH,
     Iunrep,
+    Imcyclemax,
     // Device registers
     ClintMtimecmp,
     PlicGirqpend,
@@ -288,7 +338,7 @@ export enum Reg {
     UarchX31,
     UarchPc,
     UarchCycle,
-    UarchHaltFlag,
+    UarchHalt,
     // Views of registers
     HtifToHostDev,
     HtifToHostCmd,
@@ -328,7 +378,10 @@ export interface CartesiMachine {
     getInitialConfig(): MachineConfig;
     getAddressRanges(): AddressRangeDescription[];
     getRegAddress(reg: Reg): bigint;
+    getAddressName(paddr: bigint): string;
     getRootHash(): Buffer;
+    readRevertRootHash(): Buffer;
+    writeRevertRootHash(hash: Buffer): void;
     getNodeHash(address: bigint, log2Size: number): Buffer;
     getProof(address: bigint, log2Size: number, log2RootSize?: number): Proof;
     readWord(address: bigint): bigint;
@@ -344,29 +397,34 @@ export interface CartesiMachine {
     runUarch(uarchCycleEnd: bigint): UarchBreakReason;
     resetUarch(): void;
     receiveCmioRequest(): {
-        cmd: CmioYieldCommand;
-        reason: CmioYieldReason;
+        cmd: HtifYieldCommand;
+        reason: HtifYieldReason;
         data: Buffer;
     };
-    sendCmioResponse(reason: CmioYieldReason, data: Buffer): void;
+    sendCmioResponse(
+        reason: HtifYieldReason,
+        data: Buffer,
+        revertRootHash?: Buffer,
+    ): void;
     logStep(mcycleCount: bigint, logFilename: string): BreakReason;
     logStepUarch(logType: AccessLogType): AccessLog;
     logResetUarch(logType: AccessLogType): AccessLog;
     logSendCmioResponse(
-        reason: CmioYieldReason,
+        reason: HtifYieldReason,
         data: Buffer,
         logType: AccessLogType,
+        revertRootHash?: Buffer,
     ): string;
     verifyStepUarch(
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter: Buffer,
-    ): void;
+        rootHashAfter?: Buffer,
+    ): Buffer;
     verifyResetUarch(
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter: Buffer,
-    ): void;
+        rootHashAfter?: Buffer,
+    ): Buffer;
     verifyHashTree(): boolean;
     getHashTreeStats(clear?: boolean): HashTreeStats;
 }
@@ -405,12 +463,16 @@ export function getRegAddress(reg: Reg): bigint {
     return NodeCartesiMachine.getRegAddress(reg);
 }
 
+export function getAddressName(paddr: bigint): string {
+    return NodeCartesiMachine.getAddressName(paddr);
+}
+
 export function verifyStep(
     rootHashBefore: Buffer,
     logFilename: string,
     mcycleCount: bigint,
-    rootHashAfter: Buffer,
-): BreakReason {
+    rootHashAfter?: Buffer,
+): Buffer {
     return NodeCartesiMachine.verifyStep(
         rootHashBefore,
         logFilename,
@@ -422,27 +484,37 @@ export function verifyStep(
 export function verifyStepUarch(
     rootHashBefore: Buffer,
     log: AccessLog,
-    rootHashAfter: Buffer,
-) {
-    NodeCartesiMachine.verifyStepUarch(rootHashBefore, log, rootHashAfter);
+    rootHashAfter?: Buffer,
+): Buffer {
+    return NodeCartesiMachine.verifyStepUarch(
+        rootHashBefore,
+        log,
+        rootHashAfter,
+    );
 }
 
 export function verifyResetUarch(
     rootHashBefore: Buffer,
     log: AccessLog,
-    rootHashAfter: Buffer,
-): void {
-    NodeCartesiMachine.verifyResetUarch(rootHashBefore, log, rootHashAfter);
+    rootHashAfter?: Buffer,
+): Buffer {
+    return NodeCartesiMachine.verifyResetUarch(
+        rootHashBefore,
+        log,
+        rootHashAfter,
+    );
 }
 
 export function verifySendCmioResponse(
-    reason: CmioYieldReason,
+    revertRootHash: Buffer,
+    reason: HtifYieldReason,
     data: Buffer,
     rootHashBefore: Buffer,
     log: AccessLog,
-    rootHashAfter: Buffer,
-) {
-    NodeCartesiMachine.verifySendCmioResponse(
+    rootHashAfter?: Buffer,
+): Buffer {
+    return NodeCartesiMachine.verifySendCmioResponse(
+        revertRootHash,
         reason,
         data,
         rootHashBefore,

--- a/packages/bindings/cm/src/cartesi-machine.ts
+++ b/packages/bindings/cm/src/cartesi-machine.ts
@@ -372,6 +372,7 @@ export interface CartesiMachine {
     cloneEmpty(): CartesiMachine;
     store(dir: string, sharing?: SharingMode): CartesiMachine;
     cloneStored(fromDir: string, toDir: string): void;
+    renameStored(fromDir: string, toDir: string): void;
     removeStored(dir: string): void;
     syncStored(dir: string): void;
     destroy(): void;
@@ -419,16 +420,8 @@ export interface CartesiMachine {
         logType: AccessLogType,
         revertRootHash?: Buffer,
     ): string;
-    verifyStepUarch(
-        rootHashBefore: Buffer,
-        log: AccessLog,
-        rootHashAfter?: Buffer,
-    ): Buffer;
-    verifyResetUarch(
-        rootHashBefore: Buffer,
-        log: AccessLog,
-        rootHashAfter?: Buffer,
-    ): Buffer;
+    verifyStepUarch(rootHashBefore: Buffer, log: AccessLog): Buffer;
+    verifyResetUarch(rootHashBefore: Buffer, log: AccessLog): Buffer;
     verifyHashTree(): boolean;
     getHashTreeStats(clear?: boolean): HashTreeStats;
 }
@@ -475,54 +468,40 @@ export function verifyStep(
     rootHashBefore: Buffer,
     logFilename: string,
     mcycleCount: bigint,
-    rootHashAfter?: Buffer,
 ): Buffer {
     return NodeCartesiMachine.verifyStep(
         rootHashBefore,
         logFilename,
         mcycleCount,
-        rootHashAfter,
     );
 }
 
 export function verifyStepUarch(
     rootHashBefore: Buffer,
     log: AccessLog,
-    rootHashAfter?: Buffer,
 ): Buffer {
-    return NodeCartesiMachine.verifyStepUarch(
-        rootHashBefore,
-        log,
-        rootHashAfter,
-    );
+    return NodeCartesiMachine.verifyStepUarch(rootHashBefore, log);
 }
 
 export function verifyResetUarch(
     rootHashBefore: Buffer,
     log: AccessLog,
-    rootHashAfter?: Buffer,
 ): Buffer {
-    return NodeCartesiMachine.verifyResetUarch(
-        rootHashBefore,
-        log,
-        rootHashAfter,
-    );
+    return NodeCartesiMachine.verifyResetUarch(rootHashBefore, log);
 }
 
 export function verifySendCmioResponse(
-    revertRootHash: Buffer,
     reason: HtifYieldReason,
     data: Buffer,
     rootHashBefore: Buffer,
     log: AccessLog,
-    rootHashAfter?: Buffer,
+    revertRootHash: Buffer,
 ): Buffer {
     return NodeCartesiMachine.verifySendCmioResponse(
-        revertRootHash,
         reason,
         data,
         rootHashBefore,
         log,
-        rootHashAfter,
+        revertRootHash,
     );
 }

--- a/packages/bindings/cm/src/node/addon.ts
+++ b/packages/bindings/cm/src/node/addon.ts
@@ -34,6 +34,9 @@ export interface NativeMachine {
     getInitialConfig(): string;
     getAddressRanges(): string;
     getRootHash(): Buffer;
+    readRevertRootHash(): Buffer;
+    writeRevertRootHash(hash: Uint8Array): void;
+    getAddressName(paddr: bigint): string;
     getNodeHash(address: bigint, log2Size: number): Buffer;
     getProof(address: bigint, log2Size: number, log2RootSize?: number): string;
     readWord(address: bigint): bigint;
@@ -49,11 +52,16 @@ export interface NativeMachine {
     runUarch(uarchCycleEnd: bigint): number;
     resetUarch(): void;
     receiveCmioRequest(): { cmd: number; reason: number; data: Buffer };
-    sendCmioResponse(reason: number, data: Uint8Array): void;
+    sendCmioResponse(
+        revertRootHash: Uint8Array,
+        reason: number,
+        data: Uint8Array,
+    ): void;
     logStep(mcycleCount: bigint, logFilename: string): number;
     logStepUarch(logType: number): string;
     logResetUarch(logType: number): string;
     logSendCmioResponse(
+        revertRootHash: Uint8Array,
         reason: number,
         data: Uint8Array,
         logType: number,
@@ -61,20 +69,21 @@ export interface NativeMachine {
     verifyStepUarch(
         rootHashBefore: Uint8Array,
         log: string,
-        rootHashAfter: Uint8Array,
-    ): void;
+        rootHashAfter: Uint8Array | null,
+    ): Buffer;
     verifyResetUarch(
         rootHashBefore: Uint8Array,
         log: string,
-        rootHashAfter: Uint8Array,
-    ): void;
+        rootHashAfter: Uint8Array | null,
+    ): Buffer;
     verifySendCmioResponse(
+        revertRootHash: Uint8Array,
         reason: number,
         data: Uint8Array,
         rootHashBefore: Uint8Array,
         log: string,
-        rootHashAfter: Uint8Array,
-    ): void;
+        rootHashAfter: Uint8Array | null,
+    ): Buffer;
     verifyHashTree(): boolean;
     getHashTreeStats(clear: boolean): string;
     jsonrpcFork(): { machine: NativeMachine; address: string; pid: number };
@@ -106,29 +115,31 @@ export interface NativeAddon {
     ): NativeMachine;
     getDefaultConfig(): string;
     getRegAddress(reg: number): bigint;
+    getAddressName(paddr: bigint): string;
     verifyStep(
         rootHashBefore: Uint8Array,
         logFilename: string,
         mcycleCount: bigint,
-        rootHashAfter: Uint8Array,
-    ): number;
+        rootHashAfter: Uint8Array | null,
+    ): Buffer;
     verifyStepUarch(
         rootHashBefore: Uint8Array,
         log: string,
-        rootHashAfter: Uint8Array,
-    ): void;
+        rootHashAfter: Uint8Array | null,
+    ): Buffer;
     verifyResetUarch(
         rootHashBefore: Uint8Array,
         log: string,
-        rootHashAfter: Uint8Array,
-    ): void;
+        rootHashAfter: Uint8Array | null,
+    ): Buffer;
     verifySendCmioResponse(
+        revertRootHash: Uint8Array,
         reason: number,
         data: Uint8Array,
         rootHashBefore: Uint8Array,
         log: string,
-        rootHashAfter: Uint8Array,
-    ): void;
+        rootHashAfter: Uint8Array | null,
+    ): Buffer;
     jsonrpcSpawnServer(
         address: string,
         spawnTimeoutMs: number,

--- a/packages/bindings/cm/src/node/addon.ts
+++ b/packages/bindings/cm/src/node/addon.ts
@@ -15,6 +15,7 @@ import nodeGypBuild from "node-gyp-build";
  */
 export interface NativeMachine {
     isEmpty(): boolean;
+    isJsonrpcMachine(): boolean;
     create(
         config: string,
         runtimeConfig: string | null,
@@ -25,6 +26,7 @@ export interface NativeMachine {
     store(dir: string, sharing?: number): void;
     cloneStored(fromDir: string, toDir: string): void;
     removeStored(dir: string): void;
+    syncStored(dir: string): void;
     destroy(): void;
     getDefaultConfig(): string;
     getRegAddress(reg: number): bigint;

--- a/packages/bindings/cm/src/node/addon.ts
+++ b/packages/bindings/cm/src/node/addon.ts
@@ -25,6 +25,7 @@ export interface NativeMachine {
     cloneEmpty(): NativeMachine;
     store(dir: string, sharing?: number): void;
     cloneStored(fromDir: string, toDir: string): void;
+    renameStored(fromDir: string, toDir: string): void;
     removeStored(dir: string): void;
     syncStored(dir: string): void;
     destroy(): void;
@@ -55,36 +56,27 @@ export interface NativeMachine {
     resetUarch(): void;
     receiveCmioRequest(): { cmd: number; reason: number; data: Buffer };
     sendCmioResponse(
-        revertRootHash: Uint8Array,
         reason: number,
         data: Uint8Array,
+        revertRootHash: Uint8Array | null,
     ): void;
     logStep(mcycleCount: bigint, logFilename: string): number;
     logStepUarch(logType: number): string;
     logResetUarch(logType: number): string;
     logSendCmioResponse(
-        revertRootHash: Uint8Array,
         reason: number,
         data: Uint8Array,
+        revertRootHash: Uint8Array,
         logType: number,
     ): string;
-    verifyStepUarch(
-        rootHashBefore: Uint8Array,
-        log: string,
-        rootHashAfter: Uint8Array | null,
-    ): Buffer;
-    verifyResetUarch(
-        rootHashBefore: Uint8Array,
-        log: string,
-        rootHashAfter: Uint8Array | null,
-    ): Buffer;
+    verifyStepUarch(rootHashBefore: Uint8Array, log: string): Buffer;
+    verifyResetUarch(rootHashBefore: Uint8Array, log: string): Buffer;
     verifySendCmioResponse(
-        revertRootHash: Uint8Array,
         reason: number,
         data: Uint8Array,
         rootHashBefore: Uint8Array,
         log: string,
-        rootHashAfter: Uint8Array | null,
+        revertRootHash: Uint8Array,
     ): Buffer;
     verifyHashTree(): boolean;
     getHashTreeStats(clear: boolean): string;
@@ -122,25 +114,15 @@ export interface NativeAddon {
         rootHashBefore: Uint8Array,
         logFilename: string,
         mcycleCount: bigint,
-        rootHashAfter: Uint8Array | null,
     ): Buffer;
-    verifyStepUarch(
-        rootHashBefore: Uint8Array,
-        log: string,
-        rootHashAfter: Uint8Array | null,
-    ): Buffer;
-    verifyResetUarch(
-        rootHashBefore: Uint8Array,
-        log: string,
-        rootHashAfter: Uint8Array | null,
-    ): Buffer;
+    verifyStepUarch(rootHashBefore: Uint8Array, log: string): Buffer;
+    verifyResetUarch(rootHashBefore: Uint8Array, log: string): Buffer;
     verifySendCmioResponse(
-        revertRootHash: Uint8Array,
         reason: number,
         data: Uint8Array,
         rootHashBefore: Uint8Array,
         log: string,
-        rootHashAfter: Uint8Array | null,
+        revertRootHash: Uint8Array,
     ): Buffer;
     jsonrpcSpawnServer(
         address: string,

--- a/packages/bindings/cm/src/node/cartesi-machine.ts
+++ b/packages/bindings/cm/src/node/cartesi-machine.ts
@@ -183,6 +183,14 @@ export class NodeCartesiMachine implements CartesiMachine {
     }
 
     /**
+     * Checks if the machine is a remote machine controlled via the JSON-RPC
+     * API
+     */
+    isJsonrpcMachine(): boolean {
+        return call(() => this.machine.isJsonrpcMachine());
+    }
+
+    /**
      * Creates a new machine instance from configuration
      */
     create(
@@ -238,6 +246,13 @@ export class NodeCartesiMachine implements CartesiMachine {
      */
     removeStored(dir: string): void {
         call(() => this.machine.removeStored(dir));
+    }
+
+    /**
+     * Flushes all files of a previously stored machine to permanent storage
+     */
+    syncStored(dir: string): void {
+        call(() => this.machine.syncStored(dir));
     }
 
     /**

--- a/packages/bindings/cm/src/node/cartesi-machine.ts
+++ b/packages/bindings/cm/src/node/cartesi-machine.ts
@@ -2,12 +2,15 @@ import type {
     BreakReason,
     CartesiMachine,
     HtifYieldCommand,
-    HtifYieldReason,
     Reg,
     SharingMode,
     UarchBreakReason,
 } from "../cartesi-machine.js";
-import { MachineError, MAX_MCYCLE } from "../cartesi-machine.js";
+import {
+    HtifYieldReason,
+    MachineError,
+    MAX_MCYCLE,
+} from "../cartesi-machine.js";
 import type {
     AccessLog,
     AccessLogType,
@@ -242,6 +245,13 @@ export class NodeCartesiMachine implements CartesiMachine {
     }
 
     /**
+     * Renames a stored machine directory and makes the rename durable
+     */
+    renameStored(fromDir: string, toDir: string): void {
+        call(() => this.machine.renameStored(fromDir, toDir));
+    }
+
+    /**
      * Removes a stored machine directory
      */
     removeStored(dir: string): void {
@@ -442,16 +452,21 @@ export class NodeCartesiMachine implements CartesiMachine {
     /**
      * Sends a CMIO response.
      * The revert root hash is the machine root hash to revert to in case the
-     * response is eventually rejected; it defaults to the current root hash,
-     * which is the value the emulator requires for advance-state responses.
+     * response is eventually rejected. It is required for advance-state
+     * responses — where it defaults to the current root hash, the value the
+     * emulator checks for — and refused (must be absent) for other responses.
      */
     sendCmioResponse(
         reason: HtifYieldReason,
         data: Buffer,
         revertRootHash?: Buffer,
     ): void {
-        const hash = revertRootHash ?? this.getRootHash();
-        call(() => this.machine.sendCmioResponse(hash, reason, data));
+        const hash =
+            revertRootHash ??
+            (reason === HtifYieldReason.AdvanceState
+                ? this.getRootHash()
+                : null);
+        call(() => this.machine.sendCmioResponse(reason, data, hash));
     }
 
     /**
@@ -493,99 +508,61 @@ export class NodeCartesiMachine implements CartesiMachine {
         const hash = revertRootHash ?? this.getRootHash();
         return call(() =>
             this.machine.logSendCmioResponse(
-                hash,
                 reason,
                 data,
+                hash,
                 accessLogType(logType),
             ),
         );
     }
 
     /**
-     * Verifies a step; returns the root hash obtained after the step.
-     * When rootHashAfter is given it is checked against the obtained hash.
+     * Verifies a step; returns the root hash obtained after the step, for
+     * the caller to check
      */
     static verifyStep(
         rootHashBefore: Buffer,
         logFilename: string,
         mcycleCount: bigint,
-        rootHashAfter?: Buffer,
     ): Buffer {
         return call(() =>
-            addon.verifyStep(
-                rootHashBefore,
-                logFilename,
-                mcycleCount,
-                rootHashAfter ?? null,
-            ),
+            addon.verifyStep(rootHashBefore, logFilename, mcycleCount),
         );
     }
 
     /**
      * Verifies a uarch step; returns the root hash obtained after the step
      */
-    verifyStepUarch(
-        rootHashBefore: Buffer,
-        log: AccessLog,
-        rootHashAfter?: Buffer,
-    ): Buffer {
+    verifyStepUarch(rootHashBefore: Buffer, log: AccessLog): Buffer {
         return call(() =>
-            this.machine.verifyStepUarch(
-                rootHashBefore,
-                JSON.stringify(log),
-                rootHashAfter ?? null,
-            ),
+            this.machine.verifyStepUarch(rootHashBefore, JSON.stringify(log)),
         );
     }
 
     /**
      * Verifies a uarch step; returns the root hash obtained after the step
      */
-    static verifyStepUarch(
-        rootHashBefore: Buffer,
-        log: AccessLog,
-        rootHashAfter?: Buffer,
-    ): Buffer {
+    static verifyStepUarch(rootHashBefore: Buffer, log: AccessLog): Buffer {
         return call(() =>
-            addon.verifyStepUarch(
-                rootHashBefore,
-                JSON.stringify(log),
-                rootHashAfter ?? null,
-            ),
+            addon.verifyStepUarch(rootHashBefore, JSON.stringify(log)),
         );
     }
 
     /**
      * Verifies uarch reset; returns the root hash obtained after the reset
      */
-    verifyResetUarch(
-        rootHashBefore: Buffer,
-        log: AccessLog,
-        rootHashAfter?: Buffer,
-    ): Buffer {
+    verifyResetUarch(rootHashBefore: Buffer, log: AccessLog): Buffer {
         return call(() =>
-            this.machine.verifyResetUarch(
-                rootHashBefore,
-                JSON.stringify(log),
-                rootHashAfter ?? null,
-            ),
+            this.machine.verifyResetUarch(rootHashBefore, JSON.stringify(log)),
         );
     }
 
     /**
      * Verifies uarch reset; returns the root hash obtained after the reset
      */
-    static verifyResetUarch(
-        rootHashBefore: Buffer,
-        log: AccessLog,
-        rootHashAfter?: Buffer,
-    ): Buffer {
+    static verifyResetUarch(rootHashBefore: Buffer, log: AccessLog): Buffer {
         return call(() =>
-            addon.verifyResetUarch(
-                rootHashBefore,
-                JSON.stringify(log),
-                rootHashAfter ?? null,
-            ),
+            addon.verifyResetUarch(rootHashBefore, JSON.stringify(log)),
         );
     }
 
@@ -594,21 +571,19 @@ export class NodeCartesiMachine implements CartesiMachine {
      * response
      */
     verifySendCmioResponse(
-        revertRootHash: Buffer,
         reason: HtifYieldReason,
         data: Buffer,
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter?: Buffer,
+        revertRootHash: Buffer,
     ): Buffer {
         return call(() =>
             this.machine.verifySendCmioResponse(
-                revertRootHash,
                 reason,
                 data,
                 rootHashBefore,
                 JSON.stringify(log),
-                rootHashAfter ?? null,
+                revertRootHash,
             ),
         );
     }
@@ -618,21 +593,19 @@ export class NodeCartesiMachine implements CartesiMachine {
      * response
      */
     static verifySendCmioResponse(
-        revertRootHash: Buffer,
         reason: HtifYieldReason,
         data: Buffer,
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter?: Buffer,
+        revertRootHash: Buffer,
     ): Buffer {
         return call(() =>
             addon.verifySendCmioResponse(
-                revertRootHash,
                 reason,
                 data,
                 rootHashBefore,
                 JSON.stringify(log),
-                rootHashAfter ?? null,
+                revertRootHash,
             ),
         );
     }

--- a/packages/bindings/cm/src/node/cartesi-machine.ts
+++ b/packages/bindings/cm/src/node/cartesi-machine.ts
@@ -1,8 +1,8 @@
 import type {
     BreakReason,
     CartesiMachine,
-    CmioYieldCommand,
-    CmioYieldReason,
+    HtifYieldCommand,
+    HtifYieldReason,
     Reg,
     SharingMode,
     UarchBreakReason,
@@ -162,6 +162,20 @@ export class NodeCartesiMachine implements CartesiMachine {
     }
 
     /**
+     * Gets a description of what is at a given target physical address
+     */
+    getAddressName(paddr: bigint): string {
+        return call(() => this.machine.getAddressName(paddr));
+    }
+
+    /**
+     * Gets a description of what is at a given target physical address
+     */
+    static getAddressName(paddr: bigint): string {
+        return call(() => addon.getAddressName(paddr));
+    }
+
+    /**
      * Checks if the machine is empty
      */
     isEmpty(): boolean {
@@ -286,6 +300,20 @@ export class NodeCartesiMachine implements CartesiMachine {
     }
 
     /**
+     * Reads the revert root hash from the shadow state
+     */
+    readRevertRootHash(): Buffer {
+        return call(() => this.machine.readRevertRootHash());
+    }
+
+    /**
+     * Writes the revert root hash to the shadow state
+     */
+    writeRevertRootHash(hash: Buffer): void {
+        call(() => this.machine.writeRevertRootHash(hash));
+    }
+
+    /**
      * Gets a proof for a node in the hash tree
      */
     getProof(address: bigint, log2Size: number, log2RootSize?: number): Proof {
@@ -389,18 +417,26 @@ export class NodeCartesiMachine implements CartesiMachine {
      * Receives a CMIO request
      */
     receiveCmioRequest(): {
-        cmd: CmioYieldCommand;
-        reason: CmioYieldReason;
+        cmd: HtifYieldCommand;
+        reason: HtifYieldReason;
         data: Buffer;
     } {
         return call(() => this.machine.receiveCmioRequest());
     }
 
     /**
-     * Sends a CMIO response
+     * Sends a CMIO response.
+     * The revert root hash is the machine root hash to revert to in case the
+     * response is eventually rejected; it defaults to the current root hash,
+     * which is the value the emulator requires for advance-state responses.
      */
-    sendCmioResponse(reason: CmioYieldReason, data: Buffer): void {
-        call(() => this.machine.sendCmioResponse(reason, data));
+    sendCmioResponse(
+        reason: HtifYieldReason,
+        data: Buffer,
+        revertRootHash?: Buffer,
+    ): void {
+        const hash = revertRootHash ?? this.getRootHash();
+        call(() => this.machine.sendCmioResponse(hash, reason, data));
     }
 
     /**
@@ -429,15 +465,20 @@ export class NodeCartesiMachine implements CartesiMachine {
     }
 
     /**
-     * Logs CMIO response
+     * Logs CMIO response.
+     * The revert root hash defaults to the current root hash (unlike
+     * sendCmioResponse, the emulator does not check it here).
      */
     logSendCmioResponse(
-        reason: CmioYieldReason,
+        reason: HtifYieldReason,
         data: Buffer,
         logType: AccessLogType,
+        revertRootHash?: Buffer,
     ): string {
+        const hash = revertRootHash ?? this.getRootHash();
         return call(() =>
             this.machine.logSendCmioResponse(
+                hash,
                 reason,
                 data,
                 accessLogType(logType),
@@ -446,130 +487,137 @@ export class NodeCartesiMachine implements CartesiMachine {
     }
 
     /**
-     * Verifies a step
+     * Verifies a step; returns the root hash obtained after the step.
+     * When rootHashAfter is given it is checked against the obtained hash.
      */
     static verifyStep(
         rootHashBefore: Buffer,
         logFilename: string,
         mcycleCount: bigint,
-        rootHashAfter: Buffer,
-    ): BreakReason {
+        rootHashAfter?: Buffer,
+    ): Buffer {
         return call(() =>
             addon.verifyStep(
                 rootHashBefore,
                 logFilename,
                 mcycleCount,
-                rootHashAfter,
+                rootHashAfter ?? null,
             ),
         );
     }
 
     /**
-     * Verifies a uarch step
+     * Verifies a uarch step; returns the root hash obtained after the step
      */
     verifyStepUarch(
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter: Buffer,
-    ): void {
-        call(() =>
+        rootHashAfter?: Buffer,
+    ): Buffer {
+        return call(() =>
             this.machine.verifyStepUarch(
                 rootHashBefore,
                 JSON.stringify(log),
-                rootHashAfter,
+                rootHashAfter ?? null,
             ),
         );
     }
 
     /**
-     * Verifies a uarch step
+     * Verifies a uarch step; returns the root hash obtained after the step
      */
     static verifyStepUarch(
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter: Buffer,
-    ): void {
-        call(() =>
+        rootHashAfter?: Buffer,
+    ): Buffer {
+        return call(() =>
             addon.verifyStepUarch(
                 rootHashBefore,
                 JSON.stringify(log),
-                rootHashAfter,
+                rootHashAfter ?? null,
             ),
         );
     }
 
     /**
-     * Verifies uarch reset
+     * Verifies uarch reset; returns the root hash obtained after the reset
      */
     verifyResetUarch(
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter: Buffer,
-    ): void {
-        call(() =>
+        rootHashAfter?: Buffer,
+    ): Buffer {
+        return call(() =>
             this.machine.verifyResetUarch(
                 rootHashBefore,
                 JSON.stringify(log),
-                rootHashAfter,
+                rootHashAfter ?? null,
             ),
         );
     }
 
     /**
-     * Verifies uarch reset
+     * Verifies uarch reset; returns the root hash obtained after the reset
      */
     static verifyResetUarch(
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter: Buffer,
-    ): void {
-        call(() =>
+        rootHashAfter?: Buffer,
+    ): Buffer {
+        return call(() =>
             addon.verifyResetUarch(
                 rootHashBefore,
                 JSON.stringify(log),
-                rootHashAfter,
+                rootHashAfter ?? null,
             ),
         );
     }
 
     /**
-     * Verifies CMIO response
+     * Verifies CMIO response; returns the root hash obtained after the
+     * response
      */
     verifySendCmioResponse(
-        reason: CmioYieldReason,
+        revertRootHash: Buffer,
+        reason: HtifYieldReason,
         data: Buffer,
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter: Buffer,
-    ): void {
-        call(() =>
+        rootHashAfter?: Buffer,
+    ): Buffer {
+        return call(() =>
             this.machine.verifySendCmioResponse(
+                revertRootHash,
                 reason,
                 data,
                 rootHashBefore,
                 JSON.stringify(log),
-                rootHashAfter,
+                rootHashAfter ?? null,
             ),
         );
     }
 
     /**
-     * Verifies CMIO response
+     * Verifies CMIO response; returns the root hash obtained after the
+     * response
      */
     static verifySendCmioResponse(
-        reason: CmioYieldReason,
+        revertRootHash: Buffer,
+        reason: HtifYieldReason,
         data: Buffer,
         rootHashBefore: Buffer,
         log: AccessLog,
-        rootHashAfter: Buffer,
-    ): void {
-        call(() =>
+        rootHashAfter?: Buffer,
+    ): Buffer {
+        return call(() =>
             addon.verifySendCmioResponse(
+                revertRootHash,
                 reason,
                 data,
                 rootHashBefore,
                 JSON.stringify(log),
-                rootHashAfter,
+                rootHashAfter ?? null,
             ),
         );
     }

--- a/packages/bindings/cm/src/rollups.ts
+++ b/packages/bindings/cm/src/rollups.ts
@@ -1,6 +1,6 @@
 import {
     BreakReason,
-    CmioYieldReason,
+    HtifYieldReason,
     type CartesiMachine,
 } from "./cartesi-machine.js";
 import { NodeRemoteCartesiMachine } from "./node/remote-cartesi-machine.js";
@@ -182,7 +182,7 @@ abstract class RollupsMachineImpl implements RollupsMachine {
             const machine = this.startTransaction();
 
             // write input
-            machine.sendCmioResponse(CmioYieldReason.AdvanceState, input);
+            machine.sendCmioResponse(HtifYieldReason.AdvanceState, input);
 
             while (true) {
                 // run machine until it yields or halts
@@ -192,18 +192,18 @@ abstract class RollupsMachineImpl implements RollupsMachine {
                     case BreakReason.YieldedManually: {
                         const { reason, data } = machine.receiveCmioRequest();
                         switch (reason) {
-                            case CmioYieldReason.ManualRxAccepted: {
+                            case HtifYieldReason.ManualRxAccepted: {
                                 // input was accepted
                                 // shutdown the backup fork if it exists
                                 this.commitTransaction(machine);
                                 return data;
                             }
-                            case CmioYieldReason.ManualRxRejected: {
+                            case HtifYieldReason.ManualRxRejected: {
                                 // input was rejected
                                 this.rollbackTransaction(machine);
                                 throw new RollupsInputRejectedError();
                             }
-                            case CmioYieldReason.ManualTxException: {
+                            case HtifYieldReason.ManualTxException: {
                                 // exception
                                 this.rollbackTransaction(machine);
 
@@ -221,7 +221,7 @@ abstract class RollupsMachineImpl implements RollupsMachine {
                     case BreakReason.YieldedAutomatically: {
                         const { reason, data } = machine.receiveCmioRequest();
                         switch (reason) {
-                            case CmioYieldReason.AutomaticProgress: {
+                            case HtifYieldReason.AutomaticProgress: {
                                 try {
                                     const progress = data.readUInt32LE();
                                     yield {
@@ -233,11 +233,11 @@ abstract class RollupsMachineImpl implements RollupsMachine {
                                 }
                                 break;
                             }
-                            case CmioYieldReason.AutomaticTxOutput: {
+                            case HtifYieldReason.AutomaticTxOutput: {
                                 yield { type: "output", data };
                                 break;
                             }
-                            case CmioYieldReason.AutomaticTxReport: {
+                            case HtifYieldReason.AutomaticTxReport: {
                                 yield { type: "report", data };
                                 break;
                             }
@@ -286,7 +286,7 @@ abstract class RollupsMachineImpl implements RollupsMachine {
             const machine = this.startTransaction();
 
             // write query
-            machine.sendCmioResponse(CmioYieldReason.InspectState, query);
+            machine.sendCmioResponse(HtifYieldReason.InspectState, query);
 
             while (true) {
                 // run machine until it yields or halts
@@ -296,17 +296,17 @@ abstract class RollupsMachineImpl implements RollupsMachine {
                     case BreakReason.YieldedManually: {
                         const { reason, data } = machine.receiveCmioRequest();
                         switch (reason) {
-                            case CmioYieldReason.ManualRxAccepted: {
+                            case HtifYieldReason.ManualRxAccepted: {
                                 // input was accepted
                                 this.rollbackTransaction(machine);
                                 return;
                             }
-                            case CmioYieldReason.ManualRxRejected: {
+                            case HtifYieldReason.ManualRxRejected: {
                                 // input was rejected
                                 this.rollbackTransaction(machine);
                                 throw new RollupsInputRejectedError();
                             }
-                            case CmioYieldReason.ManualTxException: {
+                            case HtifYieldReason.ManualTxException: {
                                 // exception
                                 this.rollbackTransaction(machine);
                                 const description = data.toString("utf-8"); // XXX: is this correct?
@@ -323,15 +323,15 @@ abstract class RollupsMachineImpl implements RollupsMachine {
                     case BreakReason.YieldedAutomatically: {
                         const { reason, data } = machine.receiveCmioRequest();
                         switch (reason) {
-                            case CmioYieldReason.AutomaticProgress: {
+                            case HtifYieldReason.AutomaticProgress: {
                                 // ignore progress
                                 break;
                             }
-                            case CmioYieldReason.AutomaticTxOutput: {
+                            case HtifYieldReason.AutomaticTxOutput: {
                                 // ignore output
                                 break;
                             }
-                            case CmioYieldReason.AutomaticTxReport: {
+                            case HtifYieldReason.AutomaticTxReport: {
                                 // yield report
                                 yield data;
                                 break;

--- a/packages/bindings/cm/src/types.ts
+++ b/packages/bindings/cm/src/types.ts
@@ -6,7 +6,7 @@
 // Base types
 export type UnsignedInteger = number; // integer with minimum 0
 export type Base64String = string; // string with contentEncoding: "base64"
-export type Base64Hash = string; // 32-byte hash encoded in base64 (45 chars)
+export type Base64Hash = string; // 32-byte hash encoded in base64 (44 chars)
 
 // VirtIO Device Types
 export type VirtIODeviceType = "console" | "p9fs" | "net-user" | "net-tuntap";
@@ -166,11 +166,21 @@ export interface RegistersConfig {
     senvcfg?: UnsignedInteger;
     ilrsc?: UnsignedInteger;
     iprv?: UnsignedInteger;
-    iflags_X?: UnsignedInteger;
-    iflags_Y?: UnsignedInteger;
-    iflags_H?: UnsignedInteger;
+    iflags?: IflagsConfig;
     iunrep?: UnsignedInteger;
     imcyclemax?: UnsignedInteger;
+
+    // Device registers
+    clint?: CLINTConfig;
+    plic?: PLICConfig;
+    htif?: HTIFConfig;
+}
+
+// Iflags register views
+export interface IflagsConfig {
+    X?: UnsignedInteger;
+    Y?: UnsignedInteger;
+    H?: UnsignedInteger;
 }
 
 // Processor Configuration
@@ -324,9 +334,9 @@ export interface PLICConfig {
 export interface HTIFConfig {
     fromhost?: UnsignedInteger;
     tohost?: UnsignedInteger;
-    console_getchar?: boolean;
-    yield_manual?: boolean;
-    yield_automatic?: boolean;
+    ihalt?: UnsignedInteger;
+    iconsole?: UnsignedInteger;
+    iyield?: UnsignedInteger;
 }
 
 // Microarchitecture processor registers
@@ -379,7 +389,6 @@ export interface UarchProcessorConfig {
 
 // Microarchitecture RAM Configuration
 export interface UarchRAMConfig {
-    length?: UnsignedInteger;
     backing_store?: BackingStoreConfig;
 }
 
@@ -396,8 +405,8 @@ export interface CmioBufferConfig {
 
 // CMIO Configuration
 export interface CmioConfig {
-    rx_buffer?: CmioBufferConfig;
-    tx_buffer?: CmioBufferConfig;
+    rx_buffer: CmioBufferConfig;
+    tx_buffer: CmioBufferConfig;
 }
 
 // VirtIO Host Forwarding
@@ -422,6 +431,8 @@ export interface VirtIODeviceConfig {
 export type VirtIOConfigs = VirtIODeviceConfig[];
 
 // Main Machine Configuration
+// (clint, plic, and htif moved into ProcessorConfig registers in
+// cartesi-machine 0.21)
 export interface MachineConfig {
     processor?: ProcessorConfig;
     ram: RAMConfig; // Required
@@ -430,9 +441,6 @@ export interface MachineConfig {
     nvram?: MemoryRangeConfigs;
     pmas?: PMAsConfig;
     hash_tree?: HashTreeConfig;
-    clint?: CLINTConfig;
-    plic?: PLICConfig;
-    htif?: HTIFConfig;
     uarch?: UarchConfig;
     cmio?: CmioConfig;
     virtio?: VirtIOConfigs;

--- a/packages/bindings/cm/src/types.ts
+++ b/packages/bindings/cm/src/types.ts
@@ -59,6 +59,7 @@ export interface MachineRuntimeConfig {
 export interface BackingStoreConfig {
     data_filename?: string;
     dht_filename?: string;
+    dpt_filename?: string;
     shared?: boolean;
     create?: boolean;
     truncate?: boolean;
@@ -169,6 +170,7 @@ export interface RegistersConfig {
     iflags_Y?: UnsignedInteger;
     iflags_H?: UnsignedInteger;
     iunrep?: UnsignedInteger;
+    imcyclemax?: UnsignedInteger;
 }
 
 // Processor Configuration
@@ -196,6 +198,7 @@ export interface MemoryRangeConfig {
     start?: UnsignedInteger;
     length?: UnsignedInteger;
     read_only?: boolean;
+    label?: string;
     backing_store?: BackingStoreConfig;
 }
 
@@ -204,6 +207,14 @@ export interface AddressRangeDescription {
     start?: UnsignedInteger;
     length?: UnsignedInteger;
     description?: string;
+    driver_id?: UnsignedInteger;
+    is_device?: boolean;
+    is_executable?: boolean;
+    is_memory?: boolean;
+    is_read_idempotent?: boolean;
+    is_readable?: boolean;
+    is_write_idempotent?: boolean;
+    is_writeable?: boolean;
 }
 
 // Proof
@@ -255,8 +266,12 @@ export interface AccessLog {
     brackets?: Bracket[];
 }
 
+// Memory Range Configurations (flash drives, NVRAMs)
+export type MemoryRangeConfigs = MemoryRangeConfig[];
+
 // Flash Drive Configurations (array of memory ranges)
-export type FlashDriveConfigs = MemoryRangeConfig[];
+/** @deprecated renamed to MemoryRangeConfigs in cartesi-machine 0.21 */
+export type FlashDriveConfigs = MemoryRangeConfigs;
 
 // PMAs Configuration
 export interface PMAsConfig {
@@ -353,7 +368,7 @@ export interface UarchRegistersConfig {
     // Program counter and control
     pc?: UnsignedInteger;
     cycle?: UnsignedInteger;
-    halt_flag?: boolean;
+    halt?: UnsignedInteger;
 }
 
 // Microarchitecture Processor Configuration
@@ -411,7 +426,8 @@ export interface MachineConfig {
     processor?: ProcessorConfig;
     ram: RAMConfig; // Required
     dtb?: DTBConfig;
-    flash_drive?: FlashDriveConfigs;
+    flash_drive?: MemoryRangeConfigs;
+    nvram?: MemoryRangeConfigs;
     pmas?: PMAsConfig;
     hash_tree?: HashTreeConfig;
     clint?: CLINTConfig;

--- a/packages/bindings/cm/test/cartesi-machine.test.ts
+++ b/packages/bindings/cm/test/cartesi-machine.test.ts
@@ -279,7 +279,6 @@ describe("CartesiMachine", () => {
                 rootHashBefore,
                 logFilename,
                 mcycleCount,
-                rootHashAfter,
             );
 
             expect(obtainedRootHash.equals(rootHashAfter)).toBe(true);
@@ -294,9 +293,8 @@ describe("CartesiMachine", () => {
             });
             const rootHashAfter = machine.getRootHash();
 
-            expect(() =>
-                machine.verifyStepUarch(rootHashBefore, log, rootHashAfter),
-            ).not.toThrow();
+            const obtained = machine.verifyStepUarch(rootHashBefore, log);
+            expect(obtained.equals(rootHashAfter)).toBe(true);
         });
 
         it("should verify uarch reset", () => {
@@ -307,9 +305,8 @@ describe("CartesiMachine", () => {
             });
             const rootHashAfter = machine.getRootHash();
 
-            expect(() =>
-                machine.verifyResetUarch(rootHashBefore, log, rootHashAfter),
-            ).not.toThrow();
+            const obtained = machine.verifyResetUarch(rootHashBefore, log);
+            expect(obtained.equals(rootHashAfter)).toBe(true);
         });
     });
 

--- a/packages/bindings/cm/test/cartesi-machine.test.ts
+++ b/packages/bindings/cm/test/cartesi-machine.test.ts
@@ -275,14 +275,14 @@ describe("CartesiMachine", () => {
             machine.logStep(mcycleCount, logFilename);
 
             const rootHashAfter = machine.getRootHash();
-            const breakReason = verifyStep(
+            const obtainedRootHash = verifyStep(
                 rootHashBefore,
                 logFilename,
                 mcycleCount,
                 rootHashAfter,
             );
 
-            expect(typeof breakReason).toBe("number");
+            expect(obtainedRootHash.equals(rootHashAfter)).toBe(true);
             fs.rmSync(logFilename, { force: true });
         });
 


### PR DESCRIPTION
This PR updates `@deroll/cm` to target the **v0.21.0 release** of the cartesi-machine emulator, incorporating breaking changes from the new C API. It was developed by tracking the pre-releases (test5 → test7 → test8) and finalized against v0.21.0, which is byte-identical to test8 in the public C API headers and JSON-RPC schema.

## Summary

The cartesi-machine emulator has undergone significant API changes in the 0.21 series. This update aligns the Node.js bindings with the new C API (`cm.h` and `cm-jsonrpc.h`), introducing breaking changes to the TypeScript interface and implementation.

## Key Changes

**Build layer:**
- The native addon now includes `cm.h`/`cm-jsonrpc.h` (renamed from `machine-c-api.h`/`jsonrpc-machine-c-api.h`); `find-cartesi.cjs` probes for `cm.h` and `install.cjs` reads the emulator series from `cm-version.h`, targeting **0.21**
- CI installs the v0.21.0 emulator `.deb`; the macOS release steps use a plain `brew install cartesi/tap/cartesi-machine-emulator` now that the tap ships the 0.21 formula

**Revert root hash (new 0.21 mechanism):**
- `sendCmioResponse(reason, data, revertRootHash?)`: the revert root hash is **required for advance-state responses** — where the wrapper defaults it to the machine's current root hash, the value the emulator checks for — and **must be absent for other responses** (inspect-state queries and GIO responses)
- `logSendCmioResponse` also takes it (defaults to the current root hash); `verifySendCmioResponse` requires it as its last argument, matching the C parameter order
- New `readRevertRootHash()` / `writeRevertRootHash()` methods access the revert root hash recorded in the shadow state

**Verification functions:**
- `verifyStep`, `verifyStepUarch`, `verifyResetUarch`, and `verifySendCmioResponse` no longer take a `rootHashAfter` check parameter; they **return the obtained root hash** as a `Buffer`, for the caller to check (`verifyStep` previously returned a `BreakReason`)

**Renames and enum changes:**
- `CmioYieldCommand`/`CmioYieldReason` → `HtifYieldCommand`/`HtifYieldReason` (matching the `CM_CMIO_YIELD_*` → `CM_HTIF_YIELD_*` rename)
- `ErrorCode` renumbered: `RegexError` and `SystemError` removed, later codes shifted up by 2
- `BreakReason` gained `McycleOverflow`; `UarchBreakReason` members renamed to `ReachedTargetUarchCycle`/`UarchCycleOverflow`
- `Reg` gained `Imcyclemax` (shifting device/uarch register values by one), `UarchHaltFlag` → `UarchHalt`, and the `UarchFirst_`/`UarchLast_` enumeration helpers

**New machine methods:**
- `getAddressName(paddr)` — resolves a physical address to a descriptive name (also module-level)
- `isJsonrpcMachine()` — whether the object is a remote JSON-RPC machine
- `renameStored(fromDir, toDir)` / `syncStored(dir)` — durable rename and flush of stored machines

**Machine config restructuring:**
- `clint`, `plic`, and `htif` moved from the top level into `processor.registers`; `iflags_X/Y/H` collapsed into an `iflags: {X, Y, H}` object; `HTIFConfig` now holds the `ihalt`/`iconsole`/`iyield` registers instead of booleans
- New `nvram` memory ranges, `label` on memory ranges, `dpt_filename` backing store; uarch RAM lost its `length` field; cmio `rx_buffer`/`tx_buffer` became required; `AddressRangeDescription` gained per-range attributes (`driver_id`, `is_memory`, `is_device`, …)
- `FlashDriveConfigs` renamed to `MemoryRangeConfigs` (deprecated alias kept)

**New constants:**
- `MAX_UARCH_CYCLE`, `PmaDriverId` enum, `HtifDevice`, rollup limit constants in `Constant`, and expanded `PmaConstant` addresses (CLINT, HTIF, PLIC, VirtIO, DTB, buffer lengths)

**Documentation:**
- `jsonrpc-discover.json` refreshed from the v0.21.0 tag; docs pages, README, and troubleshooting guides updated to 0.21; a changeset covers the user-facing changes

## Implementation Details

- The N-API layer mirrors the C parameter order exactly (revert root hash last in the cmio-response functions); an optional-hash helper maps null/undefined to `NULL` for the conditional revert hash
- The TypeScript wrapper computes the revert hash default lazily and only for advance-state responses, so the `rollups()` advance/inspect flows work unchanged
- `addon.cc` was syntax-checked against the actual v0.21.0 headers; the emulator itself cannot run in the development sandbox, so the integration tests rely on CI

https://claude.ai/code/session_011e1ndahzRv2oM64yyRaZVC