### PR TITLE
feat(genext2fs): add @deroll/genext2fs, Node.js bindings for xgenext2fs

### DIFF
--- a/.changeset/genext2fs-initial.md
+++ b/.changeset/genext2fs-initial.md
@@ -1,0 +1,11 @@
+---
+"@deroll/genext2fs": minor
+---
+
+Add `@deroll/genext2fs` — Node.js bindings for [xgenext2fs](https://github.com/cartesi/genext2fs), the ext2 filesystem generator, so a tar archive can be turned into a drive image from inside a Node process.
+
+`tarToExt2(tar, output, options)` is the main entry point; `tarToExt2Buffer`, `createImage` (arbitrary layers), and `genext2fs(args)` (raw argv) cover the rest, each with a blocking counterpart. Options map one to one onto the CLI flags, errors carry the tool's own diagnostics, and gzipped archives are inflated transparently.
+
+Both upstream projects are vendored as git submodules and compiled unmodified into the addon: `cartesi/genext2fs` at `v1.5.6`, plus the 16 translation units of `libarchive` `v3.8.9` needed to read a tar. Neither build system runs — hand-written `config.h` files under `config/` replace the generated ones — so the addon links against nothing but libc.
+
+Note this package is GPL-2.0-only, inherited from xgenext2fs, unlike the Apache-2.0 packages around it.

--- a/.changeset/genext2fs-initial.md
+++ b/.changeset/genext2fs-initial.md
@@ -4,7 +4,7 @@
 
 Add `@deroll/genext2fs` — Node.js bindings for [xgenext2fs](https://github.com/cartesi/genext2fs), the ext2 filesystem generator, so a tar archive can be turned into a drive image from inside a Node process.
 
-`tarToExt2(tar, output, options)` is the main entry point; `tarToExt2Buffer`, `createImage` (arbitrary layers), and `genext2fs(args)` (raw argv) cover the rest, each with a blocking counterpart. Options map one to one onto the CLI flags, errors carry the tool's own diagnostics, and gzipped archives are inflated transparently.
+`tarToExt2(tar, output, options)` is the main entry point, with `createImage(output, options)` covering images assembled from several layers; both have a blocking counterpart. Options map one to one onto the CLI flags — every one of them except `--help` and `--version`, so no raw-argv escape hatch is needed. Errors carry the tool's own diagnostics, and gzipped archives are inflated transparently.
 
 Both upstream projects are vendored as git submodules and compiled unmodified into the addon: `cartesi/genext2fs` at `v1.5.6`, plus the 16 translation units of `libarchive` `v3.8.9` needed to read a tar. Neither build system runs — hand-written `config.h` files under `config/` replace the generated ones — so the addon links against nothing but libc.
 

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -15,7 +15,8 @@
     "@deroll/cmio": "0.1.0",
     "@deroll/decoder": "0.1.0",
     "@deroll/json-decoder": "0.1.0",
-    "@deroll/mock-server": "0.1.0"
+    "@deroll/mock-server": "0.1.0",
+    "@deroll/genext2fs": "0.1.0"
   },
   "changesets": [
     "api-alpha12-withdrawals",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         outputs:
             publish: ${{ steps.check.outputs.publish }}
             cm-publish: ${{ steps.check-cm.outputs.publish }}
+            genext2fs-publish: ${{ steps.check-genext2fs.outputs.publish }}
         steps:
             - uses: actions/checkout@v6
             - uses: actions/setup-node@v6
@@ -59,6 +60,53 @@ jobs:
                       echo "publish=true" >> "$GITHUB_OUTPUT"
                       echo "@deroll/cm@${LOCAL} not yet published -> build platform packages."
                   fi
+            - id: check-genext2fs
+              run: |
+                  LOCAL=$(node -p "require('./packages/bindings/genext2fs/package.json').version")
+                  if npm view "@deroll/genext2fs@${LOCAL}" version >/dev/null 2>&1; then
+                      echo "publish=false" >> "$GITHUB_OUTPUT"
+                      echo "@deroll/genext2fs@${LOCAL} already on npm -> skip prebuilds."
+                  else
+                      echo "publish=true" >> "$GITHUB_OUTPUT"
+                      echo "@deroll/genext2fs@${LOCAL} not yet published -> build prebuilds."
+                  fi
+
+    # @deroll/genext2fs native prebuilds. Unlike cmio/cm the addon links against
+    # nothing but libc (xgenext2fs and the tar half of libarchive are compiled
+    # straight from the submodules), so these jobs need no system packages, and a
+    # consumer without a prebuild can always fall back to a source build.
+    genext2fs-prebuild:
+        name: genext2fs prebuild ${{ matrix.os }}
+        needs: detect
+        if: needs.detect.outputs.genext2fs-publish == 'true'
+        strategy:
+            matrix:
+                include:
+                    - os: ubuntu-latest # linux-x64
+                    - os: ubuntu-24.04-arm # linux-arm64
+                    - os: macos-15-intel # darwin-x64
+                    - os: macos-latest # darwin-arm64
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  # deps/genext2fs and deps/libarchive are compiled into the addon
+                  submodules: recursive
+            - uses: oven-sh/setup-bun@v2
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+            # only genext2fs is built here, so skip the install scripts of the
+            # sibling native packages, which need the emulator distribution
+            - run: bun install --frozen-lockfile --ignore-scripts
+            - name: Build prebuild
+              working-directory: packages/bindings/genext2fs
+              run: bun run prebuild:native
+            - uses: actions/upload-artifact@v7
+              with:
+                  name: genext2fs-prebuilds-${{ matrix.os }}
+                  if-no-files-found: error
+                  path: packages/bindings/genext2fs/prebuilds/
 
     # @deroll/cmio native prebuilds, built from the exact commit being published
     # (linux-x64/arm64, darwin-x64/arm64). Each job uploads a prebuilds-<os>
@@ -198,7 +246,8 @@ jobs:
 
     release:
         name: Release
-        needs: [detect, prebuild, prebuild-riscv64, cm-platform]
+        needs:
+            [detect, prebuild, prebuild-riscv64, cm-platform, genext2fs-prebuild]
         # Run when creating the Version PR (publish=false, prebuilds skipped), or
         # when publishing AND every prebuild succeeded. Never publish a native
         # package without its prebuilds: a prebuild failure blocks the release
@@ -208,7 +257,9 @@ jobs:
             (needs.detect.outputs.publish == 'false' ||
              (needs.prebuild.result == 'success' && needs.prebuild-riscv64.result == 'success')) &&
             (needs.detect.outputs.cm-publish == 'false' ||
-             needs.cm-platform.result == 'success')
+             needs.cm-platform.result == 'success') &&
+            (needs.detect.outputs.genext2fs-publish == 'false' ||
+             needs.genext2fs-prebuild.result == 'success')
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Repo
@@ -264,6 +315,16 @@ jobs:
                   pattern: cm-platform-*
                   merge-multiple: true
                   path: packages/bindings/cm/npm
+
+            # Same for @deroll/genext2fs: pack the prebuilds so installing does
+            # not have to compile the addon.
+            - name: Collect genext2fs prebuilds
+              if: needs.detect.outputs.genext2fs-publish == 'true'
+              uses: actions/download-artifact@v8
+              with:
+                  pattern: genext2fs-prebuilds-*
+                  merge-multiple: true
+                  path: packages/bindings/genext2fs/prebuilds
 
             - name: Create Release Pull Request or Publish to npm
               id: changesets

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,9 @@
 [submodule "packages/bindings/cmio/deps/machine-guest-tools"]
 	path = packages/bindings/cmio/deps/machine-guest-tools
 	url = https://github.com/cartesi/machine-guest-tools
+[submodule "packages/bindings/genext2fs/deps/genext2fs"]
+	path = packages/bindings/genext2fs/deps/genext2fs
+	url = https://github.com/cartesi/genext2fs
+[submodule "packages/bindings/genext2fs/deps/libarchive"]
+	path = packages/bindings/genext2fs/deps/libarchive
+	url = https://github.com/libarchive/libarchive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,12 @@ App pillar — `packages/app/*`:
 - **`packages/app/create-app`** (`@deroll/create-app`) — the `npm init @deroll/app` scaffolding CLI. Downloads templates and a Dockerfile from the remote `cartesi/application-templates` GitHub repo (via `got`); does not bundle templates locally.
 - **`packages/app/tsconfig`** (`@deroll/tsconfig`) — shared `base.json` TS config (strict, ES2022, ESM).
 
-Bindings pillar — `packages/bindings/*` (`@deroll/cmio`, `@deroll/cm`) and Explorer pillar — `packages/explorer/*` (`@deroll/decoder`, `@deroll/json-decoder`, `@deroll/mock-server`): being migrated in from external repos (see the umbrella-monorepo-migration plan). Not all present yet.
+Bindings pillar — `packages/bindings/*`:
+- **`packages/bindings/cmio`** (`@deroll/cmio`) — N-API binding for libcmt, compiled from the `machine-guest-tools` submodule.
+- **`packages/bindings/cm`** (`@deroll/cm`) — N-API binding for the Cartesi Machine emulator, linked against an installed emulator distribution.
+- **`packages/bindings/genext2fs`** (`@deroll/genext2fs`) — N-API binding for `xgenext2fs`, the ext2 image generator; the main entry point is `tarToExt2()`. Compiles the `genext2fs` and `libarchive` submodules straight into the addon (see its README for how the CLI is turned into a library). **GPL-2.0-only**, unlike the rest of the repo.
+
+Explorer pillar — `packages/explorer/*` (`@deroll/decoder`, `@deroll/json-decoder`, `@deroll/mock-server`): being migrated in from external repos (see the umbrella-monorepo-migration plan). Not all present yet.
 
 Apps: `apps/docs` (Vocs documentation site), `apps/examples` (runnable backend examples — `echo`, `minimal`, `router`, `wallet`, `walletRouter`, `withdraw`, `abi`), and `apps/explorer` (the explorer site, deployed to explorer.deroll.dev).
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ Now you're ready to start building your Cartesi application with cartesi and der
 
 Deroll uses [Bun](https://bun.sh) as its package manager. To install it follow the instructions [here](https://bun.sh/docs/installation).
 
+The native bindings under `packages/bindings/*` compile upstream C sources that
+are vendored as git submodules, so clone with them:
+
+```sh
+git clone --recurse-submodules https://github.com/tuler/deroll
+# or, in an existing checkout
+git submodule update --init --recursive
+```
+
 ```sh
 bun install
 ```

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,6 +15,7 @@
         "@deroll/cm": "workspace:*",
         "@deroll/cmio": "workspace:*",
         "@deroll/core": "workspace:*",
+        "@deroll/genext2fs": "workspace:*",
         "@deroll/router": "workspace:*",
         "@deroll/wallet": "workspace:*",
         "@types/react": "^19.2.17",

--- a/apps/docs/pages/genext2fs/api.mdx
+++ b/apps/docs/pages/genext2fs/api.mdx
@@ -1,0 +1,92 @@
+# API
+
+## tarToExt2
+
+Convert a tar archive into an ext2 image written to `output`. The archive is a path or its bytes; gzipped archives are inflated transparently. Resolves with the diagnostics the tool produced.
+
+```ts twoslash
+import { tarToExt2 } from "@deroll/genext2fs";
+
+const result = await tarToExt2("rootfs.tar", "rootfs.ext2", {
+    blockSize: 4096,
+    volumeLabel: "rootfs",
+    faketime: true,
+});
+console.log(result.stderr); // copying from tar archive rootfs.tar
+```
+
+## tarToExt2Buffer
+
+The same conversion, returning the image as a `Buffer`. xgenext2fs always writes to a file, so this builds in a temporary directory and reads the result back — prefer `tarToExt2` for images large enough that holding one in memory matters.
+
+```ts twoslash
+import { tarToExt2Buffer } from "@deroll/genext2fs";
+import { readFile } from "node:fs/promises";
+
+const image = await tarToExt2Buffer(await readFile("rootfs.tar.gz"), {
+    blockSize: 4096,
+});
+```
+
+## createImage
+
+The general form, for images assembled from more than one source. Layers are applied in order, each optionally at a path inside the image.
+
+```ts twoslash
+import { createImage } from "@deroll/genext2fs";
+
+await createImage("rootfs.ext2", {
+    blockSize: 4096,
+    layers: [
+        { type: "tarball", path: "rootfs.tar" },
+        { type: "directory", path: "./overlay", target: "/opt" },
+        { type: "devtable", path: "./device_table.txt" },
+    ],
+});
+```
+
+| Layer type  | Flag | Meaning                                            |
+| ----------- | ---- | -------------------------------------------------- |
+| `tarball`   | `-a` | add the contents of an archive                     |
+| `directory` | `-d` | add a directory and its contents                   |
+| `devtable`  | `-D` | create or fix up inodes from a device table file   |
+
+## genext2fs
+
+The escape hatch: run xgenext2fs with a raw argument vector (without the program name), exactly as the CLI would. No sizing retry is applied.
+
+```ts twoslash
+import { genext2fs } from "@deroll/genext2fs";
+
+await genext2fs(["-f", "-B", "4096", "-a", "rootfs.tar", "rootfs.ext2"]);
+```
+
+## Blocking variants
+
+`tarToExt2Sync`, `tarToExt2BufferSync`, `createImageSync` and `genext2fsSync` do the same work on the calling thread.
+
+## Errors
+
+Failures reject (or throw) with the tool's own diagnostic, carrying `status`, `stdout` and `stderr`.
+
+```ts twoslash
+import { type Genext2fsError, tarToExt2 } from "@deroll/genext2fs";
+
+try {
+    await tarToExt2("rootfs.tar", "rootfs.ext2", { sizeInBlocks: 8 });
+} catch (e) {
+    const error = e as Genext2fsError;
+    console.error(error.message); // couldn't allocate a block (no free space)
+    console.error(error.stderr); // everything the run printed
+}
+```
+
+## version
+
+The version of the vendored xgenext2fs the addon was built against.
+
+```ts twoslash
+import { version } from "@deroll/genext2fs";
+
+console.log(version); // "1.5.6"
+```

--- a/apps/docs/pages/genext2fs/api.mdx
+++ b/apps/docs/pages/genext2fs/api.mdx
@@ -15,15 +15,13 @@ const result = await tarToExt2("rootfs.tar", "rootfs.ext2", {
 console.log(result.stderr); // copying from tar archive rootfs.tar
 ```
 
-## tarToExt2Buffer
-
-The same conversion, returning the image as a `Buffer`. xgenext2fs always writes to a file, so this builds in a temporary directory and reads the result back — prefer `tarToExt2` for images large enough that holding one in memory matters.
+The archive can equally be passed as bytes, gzipped or not:
 
 ```ts twoslash
-import { tarToExt2Buffer } from "@deroll/genext2fs";
+import { tarToExt2 } from "@deroll/genext2fs";
 import { readFile } from "node:fs/promises";
 
-const image = await tarToExt2Buffer(await readFile("rootfs.tar.gz"), {
+await tarToExt2(await readFile("rootfs.tar.gz"), "rootfs.ext2", {
     blockSize: 4096,
 });
 ```
@@ -51,19 +49,13 @@ await createImage("rootfs.ext2", {
 | `directory` | `-d` | add a directory and its contents                   |
 | `devtable`  | `-D` | create or fix up inodes from a device table file   |
 
-## genext2fs
-
-The escape hatch: run xgenext2fs with a raw argument vector (without the program name), exactly as the CLI would. No sizing retry is applied.
-
-```ts twoslash
-import { genext2fs } from "@deroll/genext2fs";
-
-await genext2fs(["-f", "-B", "4096", "-a", "rootfs.tar", "rootfs.ext2"]);
-```
-
 ## Blocking variants
 
-`tarToExt2Sync`, `tarToExt2BufferSync`, `createImageSync` and `genext2fsSync` do the same work on the calling thread.
+`tarToExt2Sync` and `createImageSync` do the same work on the calling thread.
+
+## No escape hatch
+
+Between [Options](/genext2fs/options) and the layer types, every xgenext2fs flag is covered except `--help` and `--version` — the latter being the exported `version` — so there is no raw-argv entry point to fall back to.
 
 ## Errors
 

--- a/apps/docs/pages/genext2fs/index.mdx
+++ b/apps/docs/pages/genext2fs/index.mdx
@@ -1,0 +1,48 @@
+# genext2fs + Node.js
+
+[xgenext2fs](https://github.com/cartesi/genext2fs) is the ext2 filesystem generator Cartesi uses to turn a root filesystem into a drive image. This package binds it to Node.js as a native N-API addon, so a tar archive becomes an ext2 image without shelling out to a container or requiring `xgenext2fs` on the `PATH`.
+
+```ts twoslash
+import { tarToExt2 } from "@deroll/genext2fs";
+
+await tarToExt2("rootfs.tar", "rootfs.ext2", {
+    blockSize: 4096,
+    faketime: true,
+});
+```
+
+## Features
+
+- **Self-contained**: the addon links against nothing but libc, so the install-time source build works anywhere `node-gyp` does, and prebuilt binaries ship for Linux and macOS on x64 and arm64;
+- **Faithful**: [cartesi/genext2fs](https://github.com/cartesi/genext2fs) is compiled in unmodified, so images match what the CLI produces;
+- **Reproducible**: with [faketime](/genext2fs/options) the same archive always yields byte-identical images;
+- **Typed**: every CLI flag has a named, documented option;
+- **Non-blocking**: images are generated off the main thread, with blocking counterparts available.
+
+## Installation
+
+:::code-group
+
+```bash [pnpm]
+pnpm add @deroll/genext2fs
+```
+
+```bash [npm]
+npm install @deroll/genext2fs
+```
+
+```bash [yarn]
+yarn add @deroll/genext2fs
+```
+
+```bash [bun]
+bun add @deroll/genext2fs
+```
+
+:::
+
+On Linux (x64, arm64) and macOS (x64, arm64) this installs a prebuilt addon — no compiler needed. Elsewhere the install script compiles from source, which needs only a C/C++ toolchain: the two upstream projects are vendored and built as part of the addon, with no system libraries to install first.
+
+## License
+
+This package is **GPL-2.0-only**, inherited from xgenext2fs, which it compiles in. That differs from the other deroll packages, which are Apache-2.0 — worth knowing before linking it into a distributed application.

--- a/apps/docs/pages/genext2fs/options.mdx
+++ b/apps/docs/pages/genext2fs/options.mdx
@@ -1,0 +1,41 @@
+# Options
+
+Every option maps onto one documented xgenext2fs flag; see [`xgenext2fs.8`](https://github.com/cartesi/genext2fs/blob/cartesi/xgenext2fs.8) for the authoritative descriptions.
+
+| Option               | Flag | Meaning                                             |
+| -------------------- | ---- | --------------------------------------------------- |
+| `blockSize`          | `-B` | filesystem block size: 1024 (default), 2048 or 4096  |
+| `sizeInBlocks`       | `-b` | image size; computed from the content when omitted   |
+| `numberOfInodes`     | `-N` | minimum inode count                                  |
+| `bytesPerInode`      | `-i` | inode count derived from the size                    |
+| `readjustment`       | `-r` | grow the computed size, e.g. `"+10%"`                |
+| `volumeLabel`        | `-L` | volume label                                         |
+| `reservedPercentage` | `-m` | reserved blocks; `0` also skips `lost+found`         |
+| `creatorOs`          | `-o` | superblock creator OS                                |
+| `blockMap`           | `-g` | write a block map per path, into the current dir     |
+| `fillValue`          | `-e` | byte to fill unallocated blocks with                 |
+| `allowHoles`         | `-z` | make files with holes                                |
+| `faketime`           | `-f` | timestamp 0 everywhere, for reproducible output      |
+| `squash`             | `-q` | squash ownership and permissions to this uid         |
+| `squashUids`         | `-U` | squash ownership to this uid                         |
+| `squashPerms`        | `-P` | squash permissions, like `umask 077`                 |
+| `startingImage`      | `-x` | start from an existing image                         |
+| `verbose`            | `-v` | dump the resulting structure to `stdout`             |
+
+Sizes (`sizeInBlocks`, `numberOfInodes`, `bytesPerInode`) accept a number or a string with an IEC or SI multiplier, such as `"64Mi"`, `"1G"` or `"512k"`.
+
+## Reproducibility
+
+With `faketime` — or `SOURCE_DATE_EPOCH` in the environment, which lets you pick the timestamp — the same archive always produces byte-identical images. That is what keeps a drive's hash stable across builds.
+
+## Sizing
+
+Left to itself, xgenext2fs sizes the image from a pre-pass over the content. That estimate comes out a handful of blocks short for some archives, and the run then dies part way through with `couldn't allocate a block (no free space)` — the same happens with the upstream CLI, which is why Cartesi's tooling always passes an explicit `-b`.
+
+`createImage` and the `tarToExt2` helpers absorb this: when a run fails that way they retry with a slightly larger explicit size, derived from the size the failed attempt settled on. Both the estimate and the growth are deterministic, so images stay reproducible.
+
+Set `autoSize: false` for the raw behaviour, or pin `sizeInBlocks` to take sizing into your own hands. `genext2fs(args)` never retries.
+
+## Compressed archives
+
+The addon compiles only the tar reader out of libarchive, with no decompression filters, so gzip is inflated in JavaScript before the archive reaches the tool. Other compression formats are rejected with an explicit message rather than a tar parse error — decompress those first.

--- a/apps/docs/pages/genext2fs/options.mdx
+++ b/apps/docs/pages/genext2fs/options.mdx
@@ -11,7 +11,7 @@ Every option maps onto one documented xgenext2fs flag; see [`xgenext2fs.8`](http
 | `readjustment`       | `-r` | grow the computed size, e.g. `"+10%"`                |
 | `volumeLabel`        | `-L` | volume label                                         |
 | `reservedPercentage` | `-m` | reserved blocks; `0` also skips `lost+found`         |
-| `creatorOs`          | `-o` | superblock creator OS                                |
+| `creatorOs`          | `-o` | superblock creator OS, by name or number             |
 | `blockMap`           | `-g` | write a block map per path, into the current dir     |
 | `fillValue`          | `-e` | byte to fill unallocated blocks with                 |
 | `allowHoles`         | `-z` | make files with holes                                |
@@ -24,6 +24,10 @@ Every option maps onto one documented xgenext2fs flag; see [`xgenext2fs.8`](http
 
 Sizes (`sizeInBlocks`, `numberOfInodes`, `bytesPerInode`) accept a number or a string with an IEC or SI multiplier, such as `"64Mi"`, `"1G"` or `"512k"`.
 
+`creatorOs` takes `"linux"`, `"hurd"` (or its alias `"GNU"`), `"freebsd"`, `"lites"`, or a raw number — xgenext2fs falls back to Linux for any name it does not recognize.
+
+Together with the layer types this covers every xgenext2fs flag apart from `--help` and `--version`.
+
 ## Reproducibility
 
 With `faketime` — or `SOURCE_DATE_EPOCH` in the environment, which lets you pick the timestamp — the same archive always produces byte-identical images. That is what keeps a drive's hash stable across builds.
@@ -34,7 +38,7 @@ Left to itself, xgenext2fs sizes the image from a pre-pass over the content. Tha
 
 `createImage` and the `tarToExt2` helpers absorb this: when a run fails that way they retry with a slightly larger explicit size, derived from the size the failed attempt settled on. Both the estimate and the growth are deterministic, so images stay reproducible.
 
-Set `autoSize: false` for the raw behaviour, or pin `sizeInBlocks` to take sizing into your own hands. `genext2fs(args)` never retries.
+Set `autoSize: false` for the raw behaviour, or pin `sizeInBlocks` to take sizing into your own hands.
 
 ## Compressed archives
 

--- a/apps/docs/vocs.config.ts
+++ b/apps/docs/vocs.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
             items: [
                 { text: "cmio (libcmt)", link: "/cmio/getting-started" },
                 { text: "cm (cartesi-machine)", link: "/cm" },
+                { text: "genext2fs (ext2 images)", link: "/genext2fs" },
             ],
         },
         { text: "Explorer", link: "/explorer" },
@@ -206,6 +207,11 @@ export default defineConfig({
             { text: "Overview", link: "/explorer" },
             { text: "Writing Decoders", link: "/explorer/decoders" },
             { text: "Open explorer.deroll.dev", link: "https://explorer.deroll.dev" },
+        ],
+        "/genext2fs/": [
+            { text: "Introduction", link: "/genext2fs" },
+            { text: "API", link: "/genext2fs/api" },
+            { text: "Options", link: "/genext2fs/options" },
         ],
         "/cmio/": [
             { text: "Introduction", link: "/cmio" },

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@deroll/cm": "workspace:*",
         "@deroll/cmio": "workspace:*",
         "@deroll/core": "workspace:*",
+        "@deroll/genext2fs": "workspace:*",
         "@deroll/router": "workspace:*",
         "@deroll/wallet": "workspace:*",
         "@types/react": "^19.2.17",
@@ -233,6 +234,25 @@
         "typescript": "^6.0.3",
       },
     },
+    "packages/bindings/genext2fs": {
+      "name": "@deroll/genext2fs",
+      "version": "0.1.0",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "catalog:",
+        "@deroll/tsconfig": "workspace:*",
+        "@types/node": "^26",
+        "node-gyp": "^13.0.0",
+        "npm-run-all": "^4.1.5",
+        "prebuildify": "^6.0.1",
+        "tsup": "^8.5.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.9",
+      },
+    },
     "packages/explorer/decoder": {
       "name": "@deroll/decoder",
       "version": "0.2.0-alpha.3",
@@ -428,6 +448,8 @@
     "@deroll/examples": ["@deroll/examples@workspace:apps/examples"],
 
     "@deroll/explorer": ["@deroll/explorer@workspace:apps/explorer"],
+
+    "@deroll/genext2fs": ["@deroll/genext2fs@workspace:packages/bindings/genext2fs"],
 
     "@deroll/json-decoder": ["@deroll/json-decoder@workspace:packages/explorer/json-decoder"],
 

--- a/packages/bindings/genext2fs/.gitignore
+++ b/packages/bindings/genext2fs/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+build/
+dist/
+prebuilds/
+*.tgz
+*.tsbuildinfo

--- a/packages/bindings/genext2fs/README.md
+++ b/packages/bindings/genext2fs/README.md
@@ -1,0 +1,186 @@
+# @deroll/genext2fs
+
+Node.js bindings for [xgenext2fs](https://github.com/cartesi/genext2fs), the ext2
+filesystem generator Cartesi uses to turn a root filesystem into a drive image.
+
+The main use case is converting a tar archive into an ext2 image without leaving
+the Node process — no `docker run`, no `xgenext2fs` on the `PATH`, no temporary
+shell out:
+
+```ts
+import { tarToExt2 } from "@deroll/genext2fs";
+
+await tarToExt2("rootfs.tar", "rootfs.ext2", {
+    blockSize: 4096,
+    faketime: true,
+});
+```
+
+## Install
+
+```sh
+npm install @deroll/genext2fs
+```
+
+The addon is self-contained: it has no system dependencies beyond a C/C++
+toolchain, so the install-time source build works anywhere `node-gyp` does.
+Prebuilt binaries ship for linux and macOS on x64 and arm64.
+
+## API
+
+### `tarToExt2(tar, output, options?)`
+
+Convert a tar archive into an ext2 image written to `output`. `tar` is a path or
+the archive bytes; gzipped archives are inflated transparently. Resolves with the
+diagnostics the tool produced (`{ stdout, stderr }`).
+
+```ts
+await tarToExt2(await readFile("rootfs.tar.gz"), "rootfs.ext2", {
+    blockSize: 4096,
+    sizeInBlocks: 65536, // 256 MiB
+    volumeLabel: "rootfs",
+    faketime: true,
+});
+```
+
+### `tarToExt2Buffer(tar, options?)`
+
+Same, but returns the image as a `Buffer`. xgenext2fs always writes to a file, so
+this builds in a temporary directory and reads the result back — prefer
+`tarToExt2` for images large enough that holding one in memory matters.
+
+### `createImage(output, options?)`
+
+The general form, for images assembled from more than one source. Layers are
+applied in order, each optionally at a path inside the image:
+
+```ts
+await createImage("rootfs.ext2", {
+    blockSize: 4096,
+    layers: [
+        { type: "tarball", path: "rootfs.tar" },
+        { type: "directory", path: "./overlay", target: "/opt" },
+        { type: "devtable", path: "./device_table.txt" },
+    ],
+});
+```
+
+### `genext2fs(args)`
+
+The escape hatch: run xgenext2fs with a raw argument vector (without the program
+name), exactly as the CLI would.
+
+```ts
+await genext2fs(["-f", "-B", "4096", "-a", "rootfs.tar", "rootfs.ext2"]);
+```
+
+Every function has a blocking counterpart (`tarToExt2Sync`, `createImageSync`,
+`genext2fsSync`, …). The async ones generate the image off the main thread.
+
+### Options
+
+Each option maps onto one documented flag; see
+[`xgenext2fs.8`](https://github.com/cartesi/genext2fs/blob/cartesi/xgenext2fs.8)
+for the full descriptions.
+
+| Option               | Flag | Meaning                                              |
+| -------------------- | ---- | ---------------------------------------------------- |
+| `blockSize`          | `-B` | filesystem block size: 1024 (default), 2048 or 4096  |
+| `sizeInBlocks`       | `-b` | image size; computed from the content when omitted   |
+| `numberOfInodes`     | `-N` | minimum inode count                                  |
+| `bytesPerInode`      | `-i` | inode count derived from the size                    |
+| `readjustment`       | `-r` | grow the computed size, e.g. `"+10%"`                |
+| `volumeLabel`        | `-L` | volume label                                         |
+| `reservedPercentage` | `-m` | reserved blocks; `0` also skips `lost+found`         |
+| `creatorOs`          | `-o` | superblock creator OS                                |
+| `blockMap`           | `-g` | write a block map per path, into the current dir      |
+| `fillValue`          | `-e` | byte to fill unallocated blocks with                 |
+| `allowHoles`         | `-z` | make files with holes                                |
+| `faketime`           | `-f` | timestamp 0 everywhere, for reproducible output      |
+| `squash`             | `-q` | squash ownership and permissions to this uid         |
+| `squashUids`         | `-U` | squash ownership to this uid                         |
+| `squashPerms`        | `-P` | squash permissions, like `umask 077`                 |
+| `startingImage`      | `-x` | start from an existing image                         |
+| `verbose`            | `-v` | dump the resulting structure to `stdout`             |
+
+Errors reject (or throw) with the tool's own diagnostic, carrying `status`,
+`stdout` and `stderr`:
+
+```ts
+try {
+    await tarToExt2("rootfs.tar", "rootfs.ext2", { sizeInBlocks: 8 });
+} catch (error) {
+    console.error(error.message); // couldn't allocate a block (no free space)
+    console.error(error.stderr); // everything the run printed
+}
+```
+
+## Reproducibility
+
+With `faketime` (or `SOURCE_DATE_EPOCH` in the environment) the same archive
+always produces byte-identical images, which is what makes a drive's hash stable
+across builds.
+
+## Sizing
+
+Left to itself, xgenext2fs sizes the image from a pre-pass over the content. That
+estimate comes out a handful of blocks short for some archives, and the run then
+dies part way through with `couldn't allocate a block (no free space)` — the same
+thing happens with the upstream CLI, which is why Cartesi's tooling always passes
+an explicit `-b`.
+
+`createImage` and the `tarToExt2` helpers absorb this: when a run fails that way
+they retry with a slightly larger explicit size, derived from the size the failed
+attempt settled on. Both the estimate and the growth are deterministic, so images
+stay reproducible. Set `autoSize: false` to get the raw behaviour, or pin
+`sizeInBlocks` to take sizing into your own hands. `genext2fs(args)` never
+retries.
+
+## Compressed archives
+
+gzip is inflated in JavaScript before the archive reaches the tool. Other
+compression formats are rejected with an explicit message rather than a tar parse
+error — decompress them first.
+
+## How this is built
+
+`xgenext2fs` is a command line program, not a library: a single 100 KB
+`xgenext2fs.c` that parses `argv`, prints to `stderr`, and calls `exit()` on
+every error. Rather than fork it, this package vendors both upstream projects as
+git submodules and compiles them into the addon unmodified:
+
+- **`deps/genext2fs`** — [cartesi/genext2fs](https://github.com/cartesi/genext2fs)
+  at `v1.5.6`. `src/xgenext2fs_lib.c` textually includes `xgenext2fs.c` with
+  `main` renamed, `exit()` redirected through `longjmp()`, and `stdout`/`stderr`
+  redirected into temporary files, which is what turns the CLI into a callable
+  function whose failures unwind and whose diagnostics become strings.
+- **`deps/libarchive`** — [libarchive](https://github.com/libarchive/libarchive)
+  at `v3.8.9`, which the Cartesi fork requires for its tar reader. Only the 16
+  translation units needed to read an uncompressed tar are compiled, so the addon
+  links against nothing but libc.
+
+Neither project's build system runs: `node-gyp` cannot invoke `./configure`, so
+the two generated `config.h` files are replaced by the hand-written ones under
+[`config/`](./config), which assert the POSIX features both projects probe for
+and branch on the few that genuinely differ between Linux and Darwin.
+
+Because xgenext2fs keeps parser state in globals and `chdir()`s while reading
+directory layers, calls are serialized behind a mutex in the addon. Concurrent
+`tarToExt2` calls are safe; they just queue.
+
+### Updating the vendored sources
+
+```sh
+git -C deps/genext2fs fetch --tags && git -C deps/genext2fs checkout v1.5.7
+```
+
+Then re-check `configure.ac` against `config/genext2fs/config.h`, bump `VERSION`
+there, and rebuild. The same goes for libarchive: if the tar reader grows a new
+dependency, the build fails at link time with an undefined symbol, and the file
+list in `binding.gyp` needs the corresponding translation unit added.
+
+## License
+
+GPL-2.0-only, inherited from xgenext2fs, which this package compiles in. The
+vendored libarchive subset is BSD-2-Clause. Note that this differs from the rest
+of the deroll packages, which are Apache-2.0.

--- a/packages/bindings/genext2fs/README.md
+++ b/packages/bindings/genext2fs/README.md
@@ -43,12 +43,6 @@ await tarToExt2(await readFile("rootfs.tar.gz"), "rootfs.ext2", {
 });
 ```
 
-### `tarToExt2Buffer(tar, options?)`
-
-Same, but returns the image as a `Buffer`. xgenext2fs always writes to a file, so
-this builds in a temporary directory and reads the result back — prefer
-`tarToExt2` for images large enough that holding one in memory matters.
-
 ### `createImage(output, options?)`
 
 The general form, for images assembled from more than one source. Layers are
@@ -65,21 +59,15 @@ await createImage("rootfs.ext2", {
 });
 ```
 
-### `genext2fs(args)`
-
-The escape hatch: run xgenext2fs with a raw argument vector (without the program
-name), exactly as the CLI would.
-
-```ts
-await genext2fs(["-f", "-B", "4096", "-a", "rootfs.tar", "rootfs.ext2"]);
-```
-
-Every function has a blocking counterpart (`tarToExt2Sync`, `createImageSync`,
-`genext2fsSync`, …). The async ones generate the image off the main thread.
+Both have a blocking counterpart — `tarToExt2Sync` and `createImageSync`. The
+async ones generate the image off the main thread.
 
 ### Options
 
-Each option maps onto one documented flag; see
+Between `ImageOptions` and the layer types, every xgenext2fs flag is covered
+except `--help` and `--version` (the latter is the exported `version`), so there
+is no raw-argv escape hatch to fall back to. Each option maps onto one documented
+flag; see
 [`xgenext2fs.8`](https://github.com/cartesi/genext2fs/blob/cartesi/xgenext2fs.8)
 for the full descriptions.
 
@@ -92,7 +80,7 @@ for the full descriptions.
 | `readjustment`       | `-r` | grow the computed size, e.g. `"+10%"`                |
 | `volumeLabel`        | `-L` | volume label                                         |
 | `reservedPercentage` | `-m` | reserved blocks; `0` also skips `lost+found`         |
-| `creatorOs`          | `-o` | superblock creator OS                                |
+| `creatorOs`          | `-o` | superblock creator OS, by name or number             |
 | `blockMap`           | `-g` | write a block map per path, into the current dir      |
 | `fillValue`          | `-e` | byte to fill unallocated blocks with                 |
 | `allowHoles`         | `-z` | make files with holes                                |
@@ -133,8 +121,7 @@ an explicit `-b`.
 they retry with a slightly larger explicit size, derived from the size the failed
 attempt settled on. Both the estimate and the growth are deterministic, so images
 stay reproducible. Set `autoSize: false` to get the raw behaviour, or pin
-`sizeInBlocks` to take sizing into your own hands. `genext2fs(args)` never
-retries.
+`sizeInBlocks` to take sizing into your own hands.
 
 ## Compressed archives
 

--- a/packages/bindings/genext2fs/__tests__/genext2fs.test.ts
+++ b/packages/bindings/genext2fs/__tests__/genext2fs.test.ts
@@ -1,16 +1,14 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { gzipSync } from "node:zlib";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
     createImage,
-    genext2fs,
-    genext2fsSync,
+    createImageSync,
     tarToExt2,
-    tarToExt2Buffer,
     tarToExt2Sync,
     version,
 } from "../src/index.js";
@@ -19,7 +17,7 @@ let work: string;
 let tar: string;
 let gzipped: string;
 
-/** `dumpe2fs`/`e2fsck` are not installed everywhere; skip those assertions. */
+/** `e2fsck` is not installed everywhere; skip the assertions that need it. */
 const has = (tool: string): boolean => {
     try {
         execFileSync(tool, ["-V"], { stdio: "ignore" });
@@ -27,6 +25,16 @@ const has = (tool: string): boolean => {
     } catch {
         return false;
     }
+};
+
+/** Build an image in a throwaway file and read it back, for comparisons. */
+const image = async (
+    name: string,
+    build: (output: string) => Promise<unknown>,
+): Promise<Buffer> => {
+    const output = join(work, name);
+    await build(output);
+    return readFileSync(output);
 };
 
 beforeAll(() => {
@@ -57,50 +65,14 @@ describe("version", () => {
     });
 });
 
-describe("genext2fs", () => {
-    it("accepts a raw argument vector", async () => {
-        const output = join(work, "raw.ext2");
-        const result = await genext2fs([
-            "-f",
-            "-B",
-            "4096",
-            "-b",
-            "1024",
-            "-a",
-            tar,
-            output,
-        ]);
-        expect(result.stderr).toContain("copying from tar archive");
-        expect(statSync(output).size).toBe(1024 * 4096);
-    });
-
-    it("rejects with the tool's own diagnostic", async () => {
-        await expect(
-            genext2fs(["-a", join(work, "missing.tar"), join(work, "x.ext2")]),
-        ).rejects.toThrow(/should be a file|missing\.tar/);
-    });
-
-    it("reports errors synchronously too", () => {
-        expect(() =>
-            genext2fsSync(["--block-size", "3000", join(work, "x.ext2")]),
-        ).toThrow(/Valid block sizes/);
-    });
-
-    it("stays usable after a failed run", async () => {
-        await expect(
-            genext2fs(["-B", "3000", join(work, "x.ext2")]),
-        ).rejects.toThrow();
-        const output = join(work, "after-failure.ext2");
-        await expect(
-            genext2fs(["-f", "-b", "512", "-a", tar, output]),
-        ).resolves.toBeDefined();
-    });
-});
-
 describe("tarToExt2", () => {
     it("builds an image sized to the archive", async () => {
         const output = join(work, "auto.ext2");
-        await tarToExt2(tar, output, { blockSize: 4096, faketime: true });
+        const result = await tarToExt2(tar, output, {
+            blockSize: 4096,
+            faketime: true,
+        });
+        expect(result.stderr).toContain("copying from tar archive");
         expect(statSync(output).size).toBeGreaterThan(200_000);
     });
 
@@ -115,38 +87,35 @@ describe("tarToExt2", () => {
     });
 
     it("is reproducible with faketime", async () => {
-        const a = await tarToExt2Buffer(tar, {
-            blockSize: 4096,
-            faketime: true,
-        });
-        const b = await tarToExt2Buffer(tar, {
-            blockSize: 4096,
-            faketime: true,
-        });
+        const options = { blockSize: 4096, faketime: true } as const;
+        const a = await image("repro-a.ext2", (out) =>
+            tarToExt2(tar, out, options),
+        );
+        const b = await image("repro-b.ext2", (out) =>
+            tarToExt2(tar, out, options),
+        );
         expect(Buffer.compare(a, b)).toBe(0);
     });
 
     it("accepts the archive as bytes", async () => {
-        const fromPath = await tarToExt2Buffer(tar, {
-            blockSize: 4096,
-            faketime: true,
-        });
-        const fromBytes = await tarToExt2Buffer(readFileSync(tar), {
-            blockSize: 4096,
-            faketime: true,
-        });
+        const options = { blockSize: 4096, faketime: true } as const;
+        const fromPath = await image("from-path.ext2", (out) =>
+            tarToExt2(tar, out, options),
+        );
+        const fromBytes = await image("from-bytes.ext2", (out) =>
+            tarToExt2(readFileSync(tar), out, options),
+        );
         expect(Buffer.compare(fromPath, fromBytes)).toBe(0);
     });
 
     it("inflates gzipped archives", async () => {
-        const plain = await tarToExt2Buffer(tar, {
-            blockSize: 4096,
-            faketime: true,
-        });
-        const compressed = await tarToExt2Buffer(gzipped, {
-            blockSize: 4096,
-            faketime: true,
-        });
+        const options = { blockSize: 4096, faketime: true } as const;
+        const plain = await image("plain.ext2", (out) =>
+            tarToExt2(tar, out, options),
+        );
+        const compressed = await image("gzipped.ext2", (out) =>
+            tarToExt2(gzipped, out, options),
+        );
         expect(Buffer.compare(plain, compressed)).toBe(0);
     });
 
@@ -168,24 +137,6 @@ describe("tarToExt2", () => {
         const output = join(work, "sized.ext2");
         await tarToExt2(tar, output, { blockSize: 4096, sizeInBlocks: 2048 });
         expect(statSync(output).size).toBe(2048 * 4096);
-    });
-
-    it("unpacks at a target path inside the image", async () => {
-        if (!has("dumpe2fs")) {
-            return;
-        }
-        const output = join(work, "target.ext2");
-        // the target directory has to exist, so lay down the tree first
-        await createImage(output, {
-            blockSize: 4096,
-            faketime: true,
-            sizeInBlocks: 2048,
-            layers: [
-                { type: "tarball", path: tar },
-                { type: "tarball", path: tar, target: "/etc" },
-            ],
-        });
-        execFileSync("e2fsck", ["-fn", output], { stdio: "ignore" });
     });
 
     it("dumps the structure when verbose", async () => {
@@ -219,5 +170,110 @@ describe("tarToExt2", () => {
         for (const output of outputs.slice(1)) {
             expect(Buffer.compare(first, readFileSync(output))).toBe(0);
         }
+    });
+});
+
+describe("createImage", () => {
+    it("applies layers in order, at their target paths", async () => {
+        const output = join(work, "layers.ext2");
+        // /etc only exists once the first layer has been laid down
+        await createImage(output, {
+            blockSize: 4096,
+            faketime: true,
+            sizeInBlocks: 2048,
+            layers: [
+                { type: "tarball", path: tar },
+                { type: "tarball", path: tar, target: "/etc" },
+            ],
+        });
+        if (has("e2fsck")) {
+            execFileSync("e2fsck", ["-fn", output], { stdio: "ignore" });
+        }
+    });
+
+    it("passes the whole option surface through to the tool", async () => {
+        const result = await createImage(join(work, "options.ext2"), {
+            layers: [{ type: "tarball", path: tar }],
+            blockSize: 2048,
+            sizeInBlocks: "4Ki", // SI/IEC suffixes are parsed by the tool
+            numberOfInodes: 512,
+            bytesPerInode: 4096,
+            volumeLabel: "rootfs",
+            reservedPercentage: 0,
+            creatorOs: "freebsd",
+            fillValue: 0,
+            allowHoles: true,
+            faketime: true,
+            squashUids: 0,
+            squashPerms: true,
+            verbose: true,
+        });
+        expect(result.stdout).toContain("hello.txt");
+    });
+
+    it("rejects a layer path containing a colon", async () => {
+        await expect(
+            createImage(join(work, "colon.ext2"), {
+                layers: [{ type: "tarball", path: "/tmp/we:ird.tar" }],
+            }),
+        ).rejects.toThrow(/must not contain/);
+    });
+
+    it("surfaces the tool's own diagnostic", async () => {
+        await expect(
+            createImage(join(work, "missing.ext2"), {
+                layers: [{ type: "tarball", path: join(work, "missing.tar") }],
+            }),
+        ).rejects.toThrow(/should be a file|missing\.tar/);
+    });
+
+    it("carries status and captured output on the error", async () => {
+        try {
+            await createImage(join(work, "bad-block-size.ext2"), {
+                blockSize: 3000 as 4096,
+            });
+            expect.unreachable("expected an invalid block size to be rejected");
+        } catch (e) {
+            const error = e as Error & { status: number; stderr: string };
+            expect(error.message).toMatch(/Valid block sizes/);
+            expect(error.status).toBe(1);
+            expect(error.stderr).toContain("Valid block sizes");
+        }
+    });
+
+    it("stays usable after a failed run", () => {
+        expect(() =>
+            createImageSync(join(work, "bad.ext2"), {
+                blockSize: 3000 as 4096,
+            }),
+        ).toThrow(/Valid block sizes/);
+
+        const output = join(work, "after-failure.ext2");
+        createImageSync(output, {
+            layers: [{ type: "tarball", path: tar }],
+            blockSize: 4096,
+            faketime: true,
+        });
+        expect(statSync(output).size).toBeGreaterThan(200_000);
+    });
+
+    it("grows past an under-estimated size, and does not when told not to", async () => {
+        // this archive is one xgenext2fs sizes a few blocks short of what it
+        // needs, which is what autoSize exists to absorb
+        const output = join(work, "grow.ext2");
+        await expect(
+            createImage(output, {
+                layers: [{ type: "tarball", path: tar }],
+                blockSize: 4096,
+                autoSize: false,
+            }),
+        ).rejects.toThrow(/no free space/);
+
+        await expect(
+            createImage(output, {
+                layers: [{ type: "tarball", path: tar }],
+                blockSize: 4096,
+            }),
+        ).resolves.toBeDefined();
     });
 });

--- a/packages/bindings/genext2fs/__tests__/genext2fs.test.ts
+++ b/packages/bindings/genext2fs/__tests__/genext2fs.test.ts
@@ -1,0 +1,223 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+    createImage,
+    genext2fs,
+    genext2fsSync,
+    tarToExt2,
+    tarToExt2Buffer,
+    tarToExt2Sync,
+    version,
+} from "../src/index.js";
+
+let work: string;
+let tar: string;
+let gzipped: string;
+
+/** `dumpe2fs`/`e2fsck` are not installed everywhere; skip those assertions. */
+const has = (tool: string): boolean => {
+    try {
+        execFileSync(tool, ["-V"], { stdio: "ignore" });
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+beforeAll(() => {
+    work = mkdtempSync(join(tmpdir(), "genext2fs-test-"));
+
+    // a tree with a few of the entry kinds tar can carry
+    const root = join(work, "root");
+    mkdirSync(join(root, "etc"), { recursive: true });
+    mkdirSync(join(root, "bin"), { recursive: true });
+    writeFileSync(join(root, "etc", "hello.txt"), "hello world\n");
+    writeFileSync(join(root, "bin", "blob"), Buffer.alloc(200_000, 0x5a));
+    symlinkSync("/etc/hello.txt", join(root, "bin", "link"));
+
+    tar = join(work, "root.tar");
+    execFileSync("tar", ["--format=gnu", "-cf", tar, "-C", root, "."]);
+
+    gzipped = join(work, "root.tar.gz");
+    writeFileSync(gzipped, gzipSync(readFileSync(tar)));
+});
+
+afterAll(() => {
+    rmSync(work, { recursive: true, force: true });
+});
+
+describe("version", () => {
+    it("reports the vendored xgenext2fs version", () => {
+        expect(version).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+});
+
+describe("genext2fs", () => {
+    it("accepts a raw argument vector", async () => {
+        const output = join(work, "raw.ext2");
+        const result = await genext2fs([
+            "-f",
+            "-B",
+            "4096",
+            "-b",
+            "1024",
+            "-a",
+            tar,
+            output,
+        ]);
+        expect(result.stderr).toContain("copying from tar archive");
+        expect(statSync(output).size).toBe(1024 * 4096);
+    });
+
+    it("rejects with the tool's own diagnostic", async () => {
+        await expect(
+            genext2fs(["-a", join(work, "missing.tar"), join(work, "x.ext2")]),
+        ).rejects.toThrow(/should be a file|missing\.tar/);
+    });
+
+    it("reports errors synchronously too", () => {
+        expect(() =>
+            genext2fsSync(["--block-size", "3000", join(work, "x.ext2")]),
+        ).toThrow(/Valid block sizes/);
+    });
+
+    it("stays usable after a failed run", async () => {
+        await expect(
+            genext2fs(["-B", "3000", join(work, "x.ext2")]),
+        ).rejects.toThrow();
+        const output = join(work, "after-failure.ext2");
+        await expect(
+            genext2fs(["-f", "-b", "512", "-a", tar, output]),
+        ).resolves.toBeDefined();
+    });
+});
+
+describe("tarToExt2", () => {
+    it("builds an image sized to the archive", async () => {
+        const output = join(work, "auto.ext2");
+        await tarToExt2(tar, output, { blockSize: 4096, faketime: true });
+        expect(statSync(output).size).toBeGreaterThan(200_000);
+    });
+
+    it("produces a filesystem e2fsck considers clean", async () => {
+        if (!has("e2fsck")) {
+            return;
+        }
+        const output = join(work, "fsck.ext2");
+        await tarToExt2(tar, output, { blockSize: 4096, faketime: true });
+        // e2fsck exits 0 only when it found nothing to fix
+        execFileSync("e2fsck", ["-fn", output], { stdio: "ignore" });
+    });
+
+    it("is reproducible with faketime", async () => {
+        const a = await tarToExt2Buffer(tar, {
+            blockSize: 4096,
+            faketime: true,
+        });
+        const b = await tarToExt2Buffer(tar, {
+            blockSize: 4096,
+            faketime: true,
+        });
+        expect(Buffer.compare(a, b)).toBe(0);
+    });
+
+    it("accepts the archive as bytes", async () => {
+        const fromPath = await tarToExt2Buffer(tar, {
+            blockSize: 4096,
+            faketime: true,
+        });
+        const fromBytes = await tarToExt2Buffer(readFileSync(tar), {
+            blockSize: 4096,
+            faketime: true,
+        });
+        expect(Buffer.compare(fromPath, fromBytes)).toBe(0);
+    });
+
+    it("inflates gzipped archives", async () => {
+        const plain = await tarToExt2Buffer(tar, {
+            blockSize: 4096,
+            faketime: true,
+        });
+        const compressed = await tarToExt2Buffer(gzipped, {
+            blockSize: 4096,
+            faketime: true,
+        });
+        expect(Buffer.compare(plain, compressed)).toBe(0);
+    });
+
+    it("refuses archives compressed with something it cannot inflate", async () => {
+        const xz = join(work, "root.tar.xz");
+        writeFileSync(
+            xz,
+            Buffer.concat([
+                Buffer.from([0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00]),
+                Buffer.alloc(64),
+            ]),
+        );
+        await expect(tarToExt2(xz, join(work, "xz.ext2"))).rejects.toThrow(
+            /xz-compressed/,
+        );
+    });
+
+    it("honours an explicit size", async () => {
+        const output = join(work, "sized.ext2");
+        await tarToExt2(tar, output, { blockSize: 4096, sizeInBlocks: 2048 });
+        expect(statSync(output).size).toBe(2048 * 4096);
+    });
+
+    it("unpacks at a target path inside the image", async () => {
+        if (!has("dumpe2fs")) {
+            return;
+        }
+        const output = join(work, "target.ext2");
+        // the target directory has to exist, so lay down the tree first
+        await createImage(output, {
+            blockSize: 4096,
+            faketime: true,
+            sizeInBlocks: 2048,
+            layers: [
+                { type: "tarball", path: tar },
+                { type: "tarball", path: tar, target: "/etc" },
+            ],
+        });
+        execFileSync("e2fsck", ["-fn", output], { stdio: "ignore" });
+    });
+
+    it("dumps the structure when verbose", async () => {
+        const result = await tarToExt2(tar, join(work, "verbose.ext2"), {
+            blockSize: 4096,
+            verbose: true,
+        });
+        expect(result.stdout).toContain("hello.txt");
+    });
+
+    it("works synchronously", () => {
+        const output = join(work, "sync.ext2");
+        tarToExt2Sync(tar, output, { blockSize: 4096, faketime: true });
+        expect(statSync(output).size).toBeGreaterThan(200_000);
+    });
+
+    it("rejects an output of stdout", async () => {
+        await expect(tarToExt2(tar, "-")).rejects.toThrow(/stdout/);
+    });
+
+    it("runs concurrent conversions without interleaving", async () => {
+        const outputs = [0, 1, 2, 3].map((i) =>
+            join(work, `parallel${i}.ext2`),
+        );
+        await Promise.all(
+            outputs.map((output) =>
+                tarToExt2(tar, output, { blockSize: 4096, faketime: true }),
+            ),
+        );
+        const first = readFileSync(outputs[0]);
+        for (const output of outputs.slice(1)) {
+            expect(Buffer.compare(first, readFileSync(output))).toBe(0);
+        }
+    });
+});

--- a/packages/bindings/genext2fs/binding.gyp
+++ b/packages/bindings/genext2fs/binding.gyp
@@ -1,0 +1,98 @@
+{
+    "variables": {
+        # Neither vendored project can be built the way its own build system
+        # builds it (autotools for xgenext2fs, autotools/cmake for libarchive),
+        # so the translation units that matter are compiled directly here and
+        # the generated config.h files are replaced by the hand-written ones
+        # under config/.
+        "genext2fs_dir": "deps/genext2fs",
+        "libarchive_dir": "deps/libarchive/libarchive",
+    },
+    "targets": [
+        {
+            "target_name": "genext2fs",
+            "sources": [
+                "src/addon.cc",
+                "src/xgenext2fs_lib.c",
+                "src/libarchive_formats.c",
+                # Read-only tar support out of libarchive, and nothing else: no
+                # writers, no other formats, no decompression filters
+                # (compressed input is inflated in JS). Keeping the list this
+                # short is what makes a dependency-free static build possible.
+                "<(libarchive_dir)/archive_acl.c",
+                "<(libarchive_dir)/archive_check_magic.c",
+                "<(libarchive_dir)/archive_entry.c",
+                "<(libarchive_dir)/archive_entry_copy_stat.c",
+                "<(libarchive_dir)/archive_entry_sparse.c",
+                "<(libarchive_dir)/archive_entry_stat.c",
+                "<(libarchive_dir)/archive_entry_xattr.c",
+                "<(libarchive_dir)/archive_read.c",
+                "<(libarchive_dir)/archive_read_add_passphrase.c",
+                "<(libarchive_dir)/archive_read_open_file.c",
+                "<(libarchive_dir)/archive_read_support_filter_none.c",
+                "<(libarchive_dir)/archive_read_support_format_tar.c",
+                "<(libarchive_dir)/archive_string.c",
+                "<(libarchive_dir)/archive_string_sprintf.c",
+                "<(libarchive_dir)/archive_util.c",
+                "<(libarchive_dir)/archive_virtual.c",
+            ],
+            "include_dirs": [
+                "<!@(node -p \"require('node-addon-api').include_dir\")",
+                "src",
+                # xgenext2fs.c does `#include <config.h>`
+                "config/genext2fs",
+                # libarchive is pointed at config/libarchive-config.h below
+                "config",
+                "<(genext2fs_dir)",
+                "<(libarchive_dir)",
+            ],
+            "defines": [
+                "NAPI_VERSION=8",
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NODE_ADDON_API_DISABLE_DEPRECATED",
+                "HAVE_CONFIG_H",
+                # makes archive_platform.h skip the generated config.h
+                "PLATFORM_CONFIG_H=\"libarchive-config.h\"",
+            ],
+            "cflags": ["-O2", "-fno-strict-aliasing"],
+            # The C here is all upstream, and both projects build with warnings
+            # we are in no position to fix; silence the ones they emit so a
+            # genuine problem in our own code stands out.
+            "cflags_c": [
+                "-std=gnu99",
+                "-Wno-implicit-fallthrough",
+                "-Wno-maybe-uninitialized",
+                "-Wno-sign-compare",
+                "-Wno-stringop-truncation",
+                "-Wno-unused-function",
+                "-Wno-unused-result",
+                "-Wno-unused-variable",
+            ],
+            "cflags_cc": ["-std=c++17"],
+            "xcode_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
+                "GCC_C_LANGUAGE_STANDARD": "gnu99",
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "WARNING_CFLAGS": [
+                    "-Wno-deprecated-declarations",
+                    "-Wno-sign-compare",
+                    "-Wno-unknown-warning-option",
+                    "-Wno-unused-function",
+                    "-Wno-unused-result",
+                    "-Wno-unused-variable",
+                ],
+            },
+            "conditions": [
+                ["OS=='linux'", {
+                    # glibc/musl hide getline(3), getdelim(3) and friends behind
+                    # the GNU feature test macro
+                    "defines": ["_GNU_SOURCE"],
+                }],
+                ["OS=='mac'", {
+                    # Darwin's iconv(3) lives outside libc
+                    "libraries": ["-liconv"],
+                }],
+            ],
+        },
+    ],
+}

--- a/packages/bindings/genext2fs/biome.json
+++ b/packages/bindings/genext2fs/biome.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+    "extends": "//",
+    "files": {
+        "includes": ["**", "!deps", "!build", "!prebuilds", "!dist"]
+    }
+}

--- a/packages/bindings/genext2fs/config/genext2fs/config.h
+++ b/packages/bindings/genext2fs/config/genext2fs/config.h
@@ -1,0 +1,68 @@
+/*
+ * Hand-written replacement for the config.h that autoconf generates for
+ * xgenext2fs (deps/genext2fs/configure.ac).
+ *
+ * node-gyp cannot run `./configure`, so instead of shipping a generated header
+ * per platform we assert the small set of features xgenext2fs probes for. Every
+ * one of them is mandated by POSIX.1-2008 and present on the platforms this
+ * addon targets (glibc/musl Linux and macOS), except where noted below.
+ *
+ * Keep this in sync with the AC_CHECK_* calls in deps/genext2fs/configure.ac
+ * when bumping the submodule.
+ */
+
+#ifndef DEROLL_GENEXT2FS_CONFIG_H
+#define DEROLL_GENEXT2FS_CONFIG_H
+
+/* Must match deps/genext2fs AC_INIT([xgenext2fs], [...]) */
+#define VERSION "1.5.6"
+#define PACKAGE "xgenext2fs"
+#define PACKAGE_NAME "xgenext2fs"
+#define PACKAGE_VERSION VERSION
+#define PACKAGE_STRING "xgenext2fs " VERSION
+
+/* Headers (AC_CHECK_HEADERS / AC_HEADER_*) */
+#define HAVE_DIRENT_H 1
+#define HAVE_FCNTL_H 1
+#define HAVE_GETOPT_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LIBGEN_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_MEMORY_H 1
+#define HAVE_STDDEF_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_STAT_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_UNISTD_H 1
+
+/* Types and struct members (AC_TYPE_UID_T, AC_CHECK_MEMBERS) */
+#define HAVE_STRUCT_STAT_ST_RDEV 1
+
+/* Library functions (AC_CHECK_FUNCS) */
+#define HAVE_GETOPT_LONG 1
+#define HAVE_STRTOF 1
+
+/*
+ * getline(3) is POSIX.1-2008. Darwin only grew it in 10.7 and xgenext2fs
+ * carries a getdelim() based fallback for older systems, so declare it for the
+ * platforms we know have it and let the fallback handle the rest.
+ */
+#if defined(__linux__) || defined(__GLIBC__) || defined(__APPLE__)
+#define HAVE_GETLINE 1
+#endif
+
+/* AC_HEADER_MAJOR: where major()/minor()/makedev() live */
+#if defined(__linux__)
+#define MAJOR_IN_SYSMACROS 1
+#elif defined(__sun) || defined(sun)
+#define MAJOR_IN_MKDEV 1
+#endif
+/* On the BSDs (incl. Darwin) they come from <sys/types.h>, already included. */
+
+/* tarball support is provided by the vendored libarchive subset */
+#define HAVE_LIBARCHIVE 1
+
+#endif /* DEROLL_GENEXT2FS_CONFIG_H */

--- a/packages/bindings/genext2fs/config/libarchive-config.h
+++ b/packages/bindings/genext2fs/config/libarchive-config.h
@@ -1,0 +1,111 @@
+/*
+ * Hand-written replacement for the config.h that libarchive's configure/cmake
+ * generates, reduced to what the vendored read-only tar subset needs.
+ *
+ * Only the files listed under `libarchive_sources` in binding.gyp are compiled,
+ * so most of upstream's knobs (compression backends, ACL/xattr support, the
+ * writers, the other format readers) are deliberately left undefined. The
+ * remaining probes are POSIX.1-2008 features present on every platform this
+ * addon targets; the handful that genuinely differ between glibc/musl Linux and
+ * Darwin are selected below.
+ *
+ * libarchive picks this file up through -DPLATFORM_CONFIG_H (see
+ * deps/libarchive/libarchive/archive_platform.h), so it never looks for the
+ * generated config.h.
+ */
+
+#ifndef DEROLL_LIBARCHIVE_CONFIG_H
+#define DEROLL_LIBARCHIVE_CONFIG_H
+
+/* ------------------------------------------------------------------ headers */
+#define HAVE_ERRNO_H 1
+#define HAVE_FCNTL_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LANGINFO_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_STAT_H 1
+#define HAVE_SYS_TIME_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_TIME_H 1
+#define HAVE_UNISTD_H 1
+#define HAVE_WCHAR_H 1
+
+/* ------------------------------------------------------ declared constants */
+#define HAVE_DECL_INT32_MAX 1
+#define HAVE_DECL_INT32_MIN 1
+#define HAVE_DECL_INT64_MAX 1
+#define HAVE_DECL_INT64_MIN 1
+#define HAVE_DECL_INTMAX_MAX 1
+#define HAVE_DECL_INTMAX_MIN 1
+#define HAVE_DECL_SIZE_MAX 1
+#define HAVE_DECL_SSIZE_MAX 1
+#define HAVE_DECL_UINT32_MAX 1
+#define HAVE_DECL_UINT64_MAX 1
+#define HAVE_DECL_UINT64_MIN 1
+#define HAVE_DECL_UINTMAX_MAX 1
+
+/* --------------------------------------------------------------- functions */
+#define HAVE_FCHMOD 1
+#define HAVE_FCHOWN 1
+#define HAVE_FSEEKO 1
+#define HAVE_FUTIMENS 1
+#define HAVE_FUTIMES 1
+#define HAVE_GETEGID 1
+#define HAVE_GETEUID 1
+#define HAVE_MBRTOWC 1
+#define HAVE_MKSTEMP 1
+#define HAVE_NL_LANGINFO 1
+#define HAVE_UTIMENSAT 1
+#define HAVE_WCRTOMB 1
+#define HAVE_WCSCPY 1
+#define HAVE_WCSLEN 1
+#define HAVE_WCTOMB 1
+#define HAVE_WMEMCMP 1
+#define HAVE_WMEMCPY 1
+#define HAVE_WMEMMOVE 1
+
+/*
+ * Character set conversion. glibc, musl and Darwin all provide iconv(3); on
+ * Darwin it lives in libiconv, which binding.gyp links. Without it libarchive
+ * would fall back to a best-effort conversion and could report a warning for
+ * archives whose entry names are not valid in the current locale, which
+ * xgenext2fs treats as fatal.
+ */
+#define HAVE_ICONV 1
+#define HAVE_ICONV_H 1
+#define ICONV_CONST
+
+/* --------------------------------------------------------------- <errno.h> */
+#define HAVE_EILSEQ 1
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) ||       \
+    defined(__NetBSD__)
+/* EFTYPE is a BSD extension; libarchive maps ARCHIVE_ERRNO_FILE_FORMAT to it */
+#define HAVE_EFTYPE 1
+#endif
+
+/* ------------------------------------------------------- struct stat timing */
+#if defined(__APPLE__)
+#define HAVE_STRUCT_STAT_ST_BIRTHTIME 1
+#define HAVE_STRUCT_STAT_ST_BIRTHTIMESPEC_TV_NSEC 1
+#define HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC 1
+#define HAVE_COPYFILE_H 1
+#else
+#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
+#endif
+
+/* ------------------------------------------------------- platform specifics */
+#if defined(__linux__)
+#define MAJOR_IN_SYSMACROS 1
+#define HAVE_GETRESUID 1
+#define HAVE_LINUX_FS_H 1
+#elif defined(__sun) || defined(sun)
+#define MAJOR_IN_MKDEV 1
+#else
+#define HAVE_ISSETUGID 1
+#endif
+
+#endif /* DEROLL_LIBARCHIVE_CONFIG_H */

--- a/packages/bindings/genext2fs/package.json
+++ b/packages/bindings/genext2fs/package.json
@@ -1,0 +1,106 @@
+{
+    "name": "@deroll/genext2fs",
+    "version": "0.1.0",
+    "description": "Node.js bindings for xgenext2fs, the Cartesi ext2 filesystem generator",
+    "keywords": [
+        "cartesi",
+        "ext2",
+        "genext2fs",
+        "tar",
+        "filesystem",
+        "bindings"
+    ],
+    "license": "GPL-2.0-only",
+    "author": "Danilo Tuler",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/tuler/deroll"
+    },
+    "type": "module",
+    "main": "dist/index.cjs",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./dist/index.d.ts",
+                "import": "./dist/index.js"
+            },
+            "require": {
+                "types": "./dist/index.d.cts",
+                "require": "./dist/index.cjs"
+            }
+        },
+        "./package.json": "./package.json"
+    },
+    "scripts": {
+        "install": "node-gyp-build",
+        "build": "tsup",
+        "build:native": "node-gyp rebuild",
+        "prebuild:native": "prebuildify --napi --strip",
+        "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf build",
+        "lint": "biome check",
+        "lint:ci": "biome ci",
+        "test": "vitest run",
+        "prepack": "run-s build"
+    },
+    "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "catalog:",
+        "@deroll/tsconfig": "workspace:*",
+        "@types/node": "^26",
+        "node-gyp": "^13.0.0",
+        "npm-run-all": "^4.1.5",
+        "prebuildify": "^6.0.1",
+        "tsup": "^8.5.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.9"
+    },
+    "files": [
+        "dist",
+        "binding.gyp",
+        "config/",
+        "prebuilds/",
+        "src/addon.cc",
+        "src/libarchive_formats.c",
+        "src/xgenext2fs.h",
+        "src/xgenext2fs_lib.c",
+        "deps/genext2fs/AUTHORS",
+        "deps/genext2fs/COPYING",
+        "deps/genext2fs/cache.h",
+        "deps/genext2fs/list.h",
+        "deps/genext2fs/xgenext2fs.c",
+        "deps/libarchive/COPYING",
+        "deps/libarchive/libarchive/*.h",
+        "deps/libarchive/libarchive/archive_acl.c",
+        "deps/libarchive/libarchive/archive_check_magic.c",
+        "deps/libarchive/libarchive/archive_entry.c",
+        "deps/libarchive/libarchive/archive_entry_copy_stat.c",
+        "deps/libarchive/libarchive/archive_entry_sparse.c",
+        "deps/libarchive/libarchive/archive_entry_stat.c",
+        "deps/libarchive/libarchive/archive_entry_xattr.c",
+        "deps/libarchive/libarchive/archive_read.c",
+        "deps/libarchive/libarchive/archive_read_add_passphrase.c",
+        "deps/libarchive/libarchive/archive_read_open_file.c",
+        "deps/libarchive/libarchive/archive_read_support_filter_none.c",
+        "deps/libarchive/libarchive/archive_read_support_format_tar.c",
+        "deps/libarchive/libarchive/archive_string.c",
+        "deps/libarchive/libarchive/archive_string_sprintf.c",
+        "deps/libarchive/libarchive/archive_util.c",
+        "deps/libarchive/libarchive/archive_virtual.c"
+    ],
+    "engines": {
+        "node": ">=20"
+    },
+    "binary": {
+        "napi_versions": [
+            8
+        ]
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/bindings/genext2fs/src/addon.cc
+++ b/packages/bindings/genext2fs/src/addon.cc
@@ -1,0 +1,176 @@
+// N-API surface over xge_run() (see xgenext2fs_lib.c).
+//
+// Exposes two functions, `run` and `runSync`, both taking the argv of the
+// xgenext2fs CLI *without* the program name. Building the argv from structured
+// options is left to src/index.ts.
+//
+// xgenext2fs is not reentrant, so every call -- sync or async -- takes the same
+// mutex. `run` still releases the JS thread while the image is generated, which
+// for multi-gigabyte drives is the whole point.
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <napi.h>
+
+#include "xgenext2fs.h"
+
+namespace {
+
+std::mutex g_lock;
+
+struct Outcome {
+    int status = 0;
+    std::string out;
+    std::string err;
+};
+
+// Parse the JS argv into owned strings. C++ exceptions are disabled in this
+// addon, so bad input is reported by scheduling a JS exception and returning
+// false; callers must bail out immediately.
+bool ReadArgs(const Napi::CallbackInfo &info, std::vector<std::string> &args) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 1 || !info[0].IsArray()) {
+        Napi::TypeError::New(env, "expected an array of arguments")
+            .ThrowAsJavaScriptException();
+        return false;
+    }
+    Napi::Array array = info[0].As<Napi::Array>();
+    args.reserve(array.Length() + 1);
+    args.emplace_back("xgenext2fs");
+    for (uint32_t i = 0; i < array.Length(); i++) {
+        Napi::Value value = array.Get(i);
+        if (!value.IsString()) {
+            Napi::TypeError::New(env, "arguments must be strings")
+                .ThrowAsJavaScriptException();
+            return false;
+        }
+        args.emplace_back(value.As<Napi::String>().Utf8Value());
+    }
+    return true;
+}
+
+Outcome Invoke(const std::vector<std::string> &args) {
+    std::vector<char *> argv;
+    argv.reserve(args.size() + 1);
+    for (const std::string &arg : args) {
+        argv.push_back(const_cast<char *>(arg.c_str()));
+    }
+    argv.push_back(nullptr);
+
+    xge_result result{};
+    Outcome outcome;
+    {
+        std::lock_guard<std::mutex> guard(g_lock);
+        xge_run(static_cast<int>(args.size()), argv.data(), &result);
+        outcome.status = result.status;
+        if (result.out != nullptr) {
+            outcome.out = result.out;
+        }
+        if (result.err != nullptr) {
+            outcome.err = result.err;
+        }
+        xge_result_free(&result);
+    }
+    return outcome;
+}
+
+// Trim so the message reads like an error rather than a log dump.
+std::string ErrorMessage(const Outcome &outcome) {
+    std::string message = outcome.err;
+    while (!message.empty() && (message.back() == '\n' || message.back() == '\r')) {
+        message.pop_back();
+    }
+    // keep only the last line: earlier ones are progress, the last one is why
+    // the run died
+    const size_t split = message.find_last_of('\n');
+    if (split != std::string::npos) {
+        message = message.substr(split + 1);
+    }
+    if (message.empty()) {
+        message = "xgenext2fs exited with status " + std::to_string(outcome.status);
+    }
+    return message;
+}
+
+Napi::Object ToResult(Napi::Env env, const Outcome &outcome) {
+    Napi::Object result = Napi::Object::New(env);
+    result.Set("stdout", Napi::String::New(env, outcome.out));
+    result.Set("stderr", Napi::String::New(env, outcome.err));
+    return result;
+}
+
+Napi::Error ToError(Napi::Env env, const Outcome &outcome) {
+    Napi::Error error = Napi::Error::New(env, ErrorMessage(outcome));
+    error.Set("status", Napi::Number::New(env, outcome.status));
+    error.Set("stdout", Napi::String::New(env, outcome.out));
+    error.Set("stderr", Napi::String::New(env, outcome.err));
+    return error;
+}
+
+class RunWorker : public Napi::AsyncWorker {
+  public:
+    RunWorker(Napi::Env env, std::vector<std::string> args)
+        : Napi::AsyncWorker(env), args_(std::move(args)),
+          deferred_(Napi::Promise::Deferred::New(env)) {}
+
+    Napi::Promise Promise() { return deferred_.Promise(); }
+
+    void Execute() override { outcome_ = Invoke(args_); }
+
+    void OnOK() override {
+        Napi::Env env = Env();
+        Napi::HandleScope scope(env);
+        if (outcome_.status != 0) {
+            deferred_.Reject(ToError(env, outcome_).Value());
+        } else {
+            deferred_.Resolve(ToResult(env, outcome_));
+        }
+    }
+
+    void OnError(const Napi::Error &error) override {
+        deferred_.Reject(error.Value());
+    }
+
+  private:
+    std::vector<std::string> args_;
+    Napi::Promise::Deferred deferred_;
+    Outcome outcome_;
+};
+
+Napi::Value Run(const Napi::CallbackInfo &info) {
+    std::vector<std::string> args;
+    if (!ReadArgs(info, args)) {
+        return info.Env().Undefined();
+    }
+    RunWorker *worker = new RunWorker(info.Env(), std::move(args));
+    Napi::Promise promise = worker->Promise();
+    worker->Queue();
+    return promise;
+}
+
+Napi::Value RunSync(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+    std::vector<std::string> args;
+    if (!ReadArgs(info, args)) {
+        return env.Undefined();
+    }
+    Outcome outcome = Invoke(args);
+    if (outcome.status != 0) {
+        ToError(env, outcome).ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    return ToResult(env, outcome);
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    exports.Set("run", Napi::Function::New(env, Run));
+    exports.Set("runSync", Napi::Function::New(env, RunSync));
+    exports.Set("version", Napi::String::New(env, xge_version()));
+    return exports;
+}
+
+} // namespace
+
+NODE_API_MODULE(genext2fs, Init)

--- a/packages/bindings/genext2fs/src/addon.ts
+++ b/packages/bindings/genext2fs/src/addon.ts
@@ -1,0 +1,38 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import nodeGypBuild from "node-gyp-build";
+
+/**
+ * Raw N-API surface (see src/addon.cc). Both entry points take the xgenext2fs
+ * argv *without* the program name, and reject/throw an Error carrying `status`,
+ * `stdout` and `stderr` when the tool fails.
+ */
+export interface NativeAddon {
+    run(args: string[]): Promise<NativeResult>;
+    runSync(args: string[]): NativeResult;
+    /** version of the vendored xgenext2fs, e.g. "1.5.6" */
+    version: string;
+}
+
+export interface NativeResult {
+    stdout: string;
+    stderr: string;
+}
+
+// Package root: walk up from this file (dist/ when bundled, src/ when executed
+// from sources) until the directory containing binding.gyp.
+const findPackageRoot = (dir: string): string => {
+    let current = dir;
+    while (true) {
+        if (existsSync(join(current, "binding.gyp"))) {
+            return current;
+        }
+        const parent = dirname(current);
+        if (parent === current) {
+            throw new Error(`could not find package root from ${dir}`);
+        }
+        current = parent;
+    }
+};
+
+export const addon = nodeGypBuild(findPackageRoot(__dirname)) as NativeAddon;

--- a/packages/bindings/genext2fs/src/index.ts
+++ b/packages/bindings/genext2fs/src/index.ts
@@ -8,7 +8,7 @@ import {
     statSync,
     writeFileSync,
 } from "node:fs";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -44,22 +44,6 @@ export type TarInput = string | Uint8Array;
 
 /** Version of the vendored xgenext2fs this binding was built against. */
 export const version: string = addon.version;
-
-/**
- * Run xgenext2fs with a raw argument vector (without the program name), the
- * escape hatch for anything this package does not model. No sizing retry is
- * applied here; see {@link createImage}.
- *
- * ```ts
- * await genext2fs(["-f", "-a", "rootfs.tar", "-b", "8192", "image.ext2"]);
- * ```
- */
-export const genext2fs = (args: string[]): Promise<Genext2fsResult> =>
-    addon.run(args);
-
-/** Blocking counterpart of {@link genext2fs}. */
-export const genext2fsSync = (args: string[]): Genext2fsResult =>
-    addon.runSync(args);
 
 // -----------------------------------------------------------------------------
 // image sizing
@@ -107,6 +91,21 @@ const canResize = (options: ImageOptions): boolean =>
     options.sizeInBlocks === undefined &&
     options.startingImage === undefined;
 
+const resizePlan = (
+    output: string,
+    options: ImageOptions,
+    error: unknown,
+): number[] => {
+    if (!isExhausted(error) || !canResize(options)) {
+        return [];
+    }
+    const blocks = attemptedBlocks(
+        output,
+        options.blockSize ?? DEFAULT_BLOCK_SIZE,
+    );
+    return blocks === undefined ? [] : growthPlan(blocks);
+};
+
 /**
  * Build an ext2 image at `output` from an arbitrary set of layers.
  *
@@ -123,13 +122,12 @@ export const createImage = async (
     options: ImageOptions = {},
 ): Promise<Genext2fsResult> => {
     try {
-        return await genext2fs(buildArgs(output, options));
+        return await addon.run(buildArgs(output, options));
     } catch (error) {
-        const sizes = resizePlan(output, options, error);
         let last = error;
-        for (const sizeInBlocks of sizes) {
+        for (const sizeInBlocks of resizePlan(output, options, error)) {
             try {
-                return await genext2fs(
+                return await addon.run(
                     buildArgs(output, { ...options, sizeInBlocks }),
                 );
             } catch (retryError) {
@@ -146,13 +144,12 @@ export const createImageSync = (
     options: ImageOptions = {},
 ): Genext2fsResult => {
     try {
-        return genext2fsSync(buildArgs(output, options));
+        return addon.runSync(buildArgs(output, options));
     } catch (error) {
-        const sizes = resizePlan(output, options, error);
         let last = error;
-        for (const sizeInBlocks of sizes) {
+        for (const sizeInBlocks of resizePlan(output, options, error)) {
             try {
-                return genext2fsSync(
+                return addon.runSync(
                     buildArgs(output, { ...options, sizeInBlocks }),
                 );
             } catch (retryError) {
@@ -161,21 +158,6 @@ export const createImageSync = (
         }
         throw last;
     }
-};
-
-const resizePlan = (
-    output: string,
-    options: ImageOptions,
-    error: unknown,
-): number[] => {
-    if (!isExhausted(error) || !canResize(options)) {
-        return [];
-    }
-    const blocks = attemptedBlocks(
-        output,
-        options.blockSize ?? DEFAULT_BLOCK_SIZE,
-    );
-    return blocks === undefined ? [] : growthPlan(blocks);
 };
 
 // -----------------------------------------------------------------------------
@@ -232,6 +214,15 @@ interface Staged {
 
 const scratchPrefix = () => join(tmpdir(), "deroll-genext2fs-");
 
+const inflateSync = (tar: TarInput): Uint8Array => {
+    const bytes = typeof tar === "string" ? readFileSync(tar) : tar;
+    return detectCompression(bytes) === "gzip" ? gunzipSync(bytes) : bytes;
+};
+
+/**
+ * xgenext2fs reads the archive from a file, so bytes and gzipped input are
+ * written to a scratch directory first. An uncompressed path is used as is.
+ */
 const stageTar = async (tar: TarInput): Promise<Staged> => {
     if (
         typeof tar === "string" &&
@@ -241,7 +232,10 @@ const stageTar = async (tar: TarInput): Promise<Staged> => {
     }
     const scratch = await mkdtemp(scratchPrefix());
     const path = join(scratch, "input.tar");
-    await writeFile(path, await inflate(tar));
+    await writeFile(
+        path,
+        inflateSync(typeof tar === "string" ? await readFile(tar) : tar),
+    );
     return { path, scratch };
 };
 
@@ -256,14 +250,6 @@ const stageTarSync = (tar: TarInput): Staged => {
     const path = join(scratch, "input.tar");
     writeFileSync(path, inflateSync(tar));
     return { path, scratch };
-};
-
-const inflate = async (tar: TarInput): Promise<Uint8Array> =>
-    inflateSync(typeof tar === "string" ? await readFile(tar) : tar);
-
-const inflateSync = (tar: TarInput): Uint8Array => {
-    const bytes = typeof tar === "string" ? readFileSync(tar) : tar;
-    return detectCompression(bytes) === "gzip" ? gunzipSync(bytes) : bytes;
 };
 
 const discard = (scratch?: string): void => {
@@ -323,41 +309,5 @@ export const tarToExt2Sync = (
         return createImageSync(output, tarOptions(staged.path, options));
     } finally {
         discard(staged.scratch);
-    }
-};
-
-/**
- * Convert a tar archive into an ext2 image returned as bytes.
- *
- * xgenext2fs always writes to a file, so the image is built in a temporary
- * directory and read back; prefer {@link tarToExt2} for images large enough
- * that holding one in memory matters.
- */
-export const tarToExt2Buffer = async (
-    tar: TarInput,
-    options: TarToExt2Options = {},
-): Promise<Buffer> => {
-    const scratch = await mkdtemp(scratchPrefix());
-    try {
-        const output = join(scratch, "image.ext2");
-        await tarToExt2(tar, output, options);
-        return await readFile(output);
-    } finally {
-        await rm(scratch, { recursive: true, force: true });
-    }
-};
-
-/** Blocking counterpart of {@link tarToExt2Buffer}. */
-export const tarToExt2BufferSync = (
-    tar: TarInput,
-    options: TarToExt2Options = {},
-): Buffer => {
-    const scratch = mkdtempSync(scratchPrefix());
-    try {
-        const output = join(scratch, "image.ext2");
-        tarToExt2Sync(tar, output, options);
-        return readFileSync(output);
-    } finally {
-        discard(scratch);
     }
 };

--- a/packages/bindings/genext2fs/src/index.ts
+++ b/packages/bindings/genext2fs/src/index.ts
@@ -1,0 +1,363 @@
+import {
+    closeSync,
+    mkdtempSync,
+    openSync,
+    readFileSync,
+    readSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
+import { addon } from "./addon.js";
+import { type ImageOptions, buildArgs } from "./options.js";
+
+export type {
+    BlockSize,
+    CreatorOs,
+    Genext2fsOptions,
+    ImageOptions,
+    Layer,
+    Size,
+} from "./options.js";
+
+/** Diagnostics the tool produced while building the image. */
+export interface Genext2fsResult {
+    /** `verbose` filesystem dump, empty otherwise. */
+    stdout: string;
+    /** Progress and warnings, e.g. `copying from tar archive ...`. */
+    stderr: string;
+}
+
+/** Error thrown when xgenext2fs fails; carries its captured output. */
+export interface Genext2fsError extends Error {
+    status: number;
+    stdout: string;
+    stderr: string;
+}
+
+/** A tar archive: a path to one, or its bytes. Gzipped input is accepted. */
+export type TarInput = string | Uint8Array;
+
+/** Version of the vendored xgenext2fs this binding was built against. */
+export const version: string = addon.version;
+
+/**
+ * Run xgenext2fs with a raw argument vector (without the program name), the
+ * escape hatch for anything this package does not model. No sizing retry is
+ * applied here; see {@link createImage}.
+ *
+ * ```ts
+ * await genext2fs(["-f", "-a", "rootfs.tar", "-b", "8192", "image.ext2"]);
+ * ```
+ */
+export const genext2fs = (args: string[]): Promise<Genext2fsResult> =>
+    addon.run(args);
+
+/** Blocking counterpart of {@link genext2fs}. */
+export const genext2fsSync = (args: string[]): Genext2fsResult =>
+    addon.runSync(args);
+
+// -----------------------------------------------------------------------------
+// image sizing
+// -----------------------------------------------------------------------------
+
+const DEFAULT_BLOCK_SIZE = 1024;
+
+/**
+ * xgenext2fs derives the image size from a pre-pass over the content, and that
+ * estimate comes out a handful of blocks short for some inputs -- the run then
+ * dies part way through with this message. The estimate itself is deterministic,
+ * so retrying with a slightly larger explicit size is too.
+ */
+const EXHAUSTED = /no free space/i;
+
+/** Sizes to try, in blocks, after an estimate of `blocks` proved too small. */
+const growthPlan = (blocks: number): number[] => [
+    blocks + Math.max(32, Math.ceil(blocks * 0.05)),
+    blocks + Math.max(256, Math.ceil(blocks * 0.25)),
+];
+
+const isExhausted = (error: unknown): boolean =>
+    error instanceof Error && EXHAUSTED.test(error.message);
+
+/**
+ * Number of blocks the failed attempt sized the image for. xgenext2fs truncates
+ * the output to `blocks * blockSize` before populating it, so the partial file
+ * left behind reports the estimate it settled on.
+ */
+const attemptedBlocks = (
+    output: string,
+    blockSize: number,
+): number | undefined => {
+    try {
+        const { size } = statSync(output);
+        return size > 0 ? Math.floor(size / blockSize) : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+/** Whether a failed run is worth retrying with an explicit size. */
+const canResize = (options: ImageOptions): boolean =>
+    options.autoSize !== false &&
+    options.sizeInBlocks === undefined &&
+    options.startingImage === undefined;
+
+/**
+ * Build an ext2 image at `output` from an arbitrary set of layers.
+ *
+ * ```ts
+ * await createImage("image.ext2", {
+ *     layers: [{ type: "tarball", path: "rootfs.tar" }],
+ *     blockSize: 4096,
+ *     faketime: true,
+ * });
+ * ```
+ */
+export const createImage = async (
+    output: string,
+    options: ImageOptions = {},
+): Promise<Genext2fsResult> => {
+    try {
+        return await genext2fs(buildArgs(output, options));
+    } catch (error) {
+        const sizes = resizePlan(output, options, error);
+        let last = error;
+        for (const sizeInBlocks of sizes) {
+            try {
+                return await genext2fs(
+                    buildArgs(output, { ...options, sizeInBlocks }),
+                );
+            } catch (retryError) {
+                last = retryError;
+            }
+        }
+        throw last;
+    }
+};
+
+/** Blocking counterpart of {@link createImage}. */
+export const createImageSync = (
+    output: string,
+    options: ImageOptions = {},
+): Genext2fsResult => {
+    try {
+        return genext2fsSync(buildArgs(output, options));
+    } catch (error) {
+        const sizes = resizePlan(output, options, error);
+        let last = error;
+        for (const sizeInBlocks of sizes) {
+            try {
+                return genext2fsSync(
+                    buildArgs(output, { ...options, sizeInBlocks }),
+                );
+            } catch (retryError) {
+                last = retryError;
+            }
+        }
+        throw last;
+    }
+};
+
+const resizePlan = (
+    output: string,
+    options: ImageOptions,
+    error: unknown,
+): number[] => {
+    if (!isExhausted(error) || !canResize(options)) {
+        return [];
+    }
+    const blocks = attemptedBlocks(
+        output,
+        options.blockSize ?? DEFAULT_BLOCK_SIZE,
+    );
+    return blocks === undefined ? [] : growthPlan(blocks);
+};
+
+// -----------------------------------------------------------------------------
+// tar handling
+// -----------------------------------------------------------------------------
+
+const GZIP = [0x1f, 0x8b];
+const compressedMagics: [number[], string][] = [
+    [[0x42, 0x5a, 0x68], "bzip2"],
+    [[0xfd, 0x37, 0x7a, 0x58, 0x5a], "xz"],
+    [[0x28, 0xb5, 0x2f, 0xfd], "zstd"],
+    [[0x1f, 0x9d], "compress"],
+    [[0x04, 0x22, 0x4d, 0x18], "lz4"],
+];
+
+const startsWith = (bytes: Uint8Array, magic: number[]): boolean =>
+    magic.every((byte, index) => bytes[index] === byte);
+
+/**
+ * The vendored libarchive subset carries no decompression filters (see
+ * src/libarchive_formats.c), so gzip is inflated here and anything else is
+ * rejected with an actionable message instead of a tar parse error.
+ */
+const detectCompression = (head: Uint8Array): "none" | "gzip" => {
+    if (startsWith(head, GZIP)) {
+        return "gzip";
+    }
+    for (const [magic, name] of compressedMagics) {
+        if (startsWith(head, magic)) {
+            throw new Error(
+                `${name}-compressed archives are not supported; decompress the archive first (gzip is handled transparently)`,
+            );
+        }
+    }
+    return "none";
+};
+
+const readHead = (path: string): Uint8Array => {
+    const head = Buffer.alloc(8);
+    const fd = openSync(path, "r");
+    try {
+        const read = readSync(fd, head, 0, head.length, 0);
+        return head.subarray(0, read);
+    } finally {
+        closeSync(fd);
+    }
+};
+
+/** A tar ready for xgenext2fs, plus the scratch directory to clean up. */
+interface Staged {
+    path: string;
+    scratch?: string;
+}
+
+const scratchPrefix = () => join(tmpdir(), "deroll-genext2fs-");
+
+const stageTar = async (tar: TarInput): Promise<Staged> => {
+    if (
+        typeof tar === "string" &&
+        detectCompression(readHead(tar)) === "none"
+    ) {
+        return { path: tar };
+    }
+    const scratch = await mkdtemp(scratchPrefix());
+    const path = join(scratch, "input.tar");
+    await writeFile(path, await inflate(tar));
+    return { path, scratch };
+};
+
+const stageTarSync = (tar: TarInput): Staged => {
+    if (
+        typeof tar === "string" &&
+        detectCompression(readHead(tar)) === "none"
+    ) {
+        return { path: tar };
+    }
+    const scratch = mkdtempSync(scratchPrefix());
+    const path = join(scratch, "input.tar");
+    writeFileSync(path, inflateSync(tar));
+    return { path, scratch };
+};
+
+const inflate = async (tar: TarInput): Promise<Uint8Array> =>
+    inflateSync(typeof tar === "string" ? await readFile(tar) : tar);
+
+const inflateSync = (tar: TarInput): Uint8Array => {
+    const bytes = typeof tar === "string" ? readFileSync(tar) : tar;
+    return detectCompression(bytes) === "gzip" ? gunzipSync(bytes) : bytes;
+};
+
+const discard = (scratch?: string): void => {
+    if (scratch !== undefined) {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+};
+
+// -----------------------------------------------------------------------------
+// tar -> ext2
+// -----------------------------------------------------------------------------
+
+export interface TarToExt2Options extends Omit<ImageOptions, "layers"> {
+    /** Path inside the image to unpack the archive at. Defaults to the root. */
+    target?: string;
+}
+
+const tarOptions = (path: string, options: TarToExt2Options): ImageOptions => {
+    const { target, ...rest } = options;
+    return { ...rest, layers: [{ type: "tarball", path, target }] };
+};
+
+/**
+ * Convert a tar archive into an ext2 image written to `output`.
+ *
+ * The image is sized to fit its contents unless `sizeInBlocks` says otherwise.
+ * Gzipped archives are inflated transparently.
+ *
+ * ```ts
+ * await tarToExt2("rootfs.tar", "rootfs.ext2", {
+ *     blockSize: 4096,
+ *     faketime: true,
+ * });
+ * ```
+ */
+export const tarToExt2 = async (
+    tar: TarInput,
+    output: string,
+    options: TarToExt2Options = {},
+): Promise<Genext2fsResult> => {
+    const staged = await stageTar(tar);
+    try {
+        return await createImage(output, tarOptions(staged.path, options));
+    } finally {
+        discard(staged.scratch);
+    }
+};
+
+/** Blocking counterpart of {@link tarToExt2}. */
+export const tarToExt2Sync = (
+    tar: TarInput,
+    output: string,
+    options: TarToExt2Options = {},
+): Genext2fsResult => {
+    const staged = stageTarSync(tar);
+    try {
+        return createImageSync(output, tarOptions(staged.path, options));
+    } finally {
+        discard(staged.scratch);
+    }
+};
+
+/**
+ * Convert a tar archive into an ext2 image returned as bytes.
+ *
+ * xgenext2fs always writes to a file, so the image is built in a temporary
+ * directory and read back; prefer {@link tarToExt2} for images large enough
+ * that holding one in memory matters.
+ */
+export const tarToExt2Buffer = async (
+    tar: TarInput,
+    options: TarToExt2Options = {},
+): Promise<Buffer> => {
+    const scratch = await mkdtemp(scratchPrefix());
+    try {
+        const output = join(scratch, "image.ext2");
+        await tarToExt2(tar, output, options);
+        return await readFile(output);
+    } finally {
+        await rm(scratch, { recursive: true, force: true });
+    }
+};
+
+/** Blocking counterpart of {@link tarToExt2Buffer}. */
+export const tarToExt2BufferSync = (
+    tar: TarInput,
+    options: TarToExt2Options = {},
+): Buffer => {
+    const scratch = mkdtempSync(scratchPrefix());
+    try {
+        const output = join(scratch, "image.ext2");
+        tarToExt2Sync(tar, output, options);
+        return readFileSync(output);
+    } finally {
+        discard(scratch);
+    }
+};

--- a/packages/bindings/genext2fs/src/libarchive_formats.c
+++ b/packages/bindings/genext2fs/src/libarchive_formats.c
@@ -1,0 +1,27 @@
+/*
+ * Narrowed replacements for libarchive's archive_read_support_format_all() and
+ * archive_read_support_filter_all().
+ *
+ * Upstream's versions reference every reader libarchive ships (7zip, rar, zip,
+ * iso9660, ...) and every decompression filter (gzip, bzip2, lzma, zstd, ...),
+ * which would drag in the whole library plus zlib/bz2/lzma/zstd. xgenext2fs only
+ * ever feeds it tar archives, so the addon compiles just the tar reader and the
+ * "none" (uncompressed) filter and defines the two aggregate entry points here.
+ *
+ * Compressed input is dealt with on the JavaScript side, which decompresses
+ * before handing the bytes over -- see src/index.ts.
+ */
+
+#include <archive.h>
+
+int
+archive_read_support_format_all(struct archive *a)
+{
+    return archive_read_support_format_tar(a);
+}
+
+int
+archive_read_support_filter_all(struct archive *a)
+{
+    return archive_read_support_filter_none(a);
+}

--- a/packages/bindings/genext2fs/src/options.ts
+++ b/packages/bindings/genext2fs/src/options.ts
@@ -5,8 +5,12 @@
  * deps/genext2fs/xgenext2fs.8 for the authoritative descriptions.
  */
 
-/** Value for the creator OS field in the superblock (`-o`). */
-export type CreatorOs = "linux" | "hurd" | "masix" | "freebsd" | "lites";
+/**
+ * Value for the creator OS field in the superblock (`-o`). Anything xgenext2fs
+ * does not recognize by name falls back to Linux, so a raw number is the way to
+ * set one it has no name for.
+ */
+export type CreatorOs = "linux" | "hurd" | "GNU" | "freebsd" | "lites" | number;
 
 /** Filesystem block size in bytes (`-B`). */
 export type BlockSize = 1024 | 2048 | 4096;

--- a/packages/bindings/genext2fs/src/options.ts
+++ b/packages/bindings/genext2fs/src/options.ts
@@ -1,0 +1,218 @@
+/**
+ * Structured form of the xgenext2fs command line, and the translation to argv.
+ *
+ * Every field maps one to one onto a documented flag; see
+ * deps/genext2fs/xgenext2fs.8 for the authoritative descriptions.
+ */
+
+/** Value for the creator OS field in the superblock (`-o`). */
+export type CreatorOs = "linux" | "hurd" | "masix" | "freebsd" | "lites";
+
+/** Filesystem block size in bytes (`-B`). */
+export type BlockSize = 1024 | 2048 | 4096;
+
+/**
+ * Sizes accepted by xgenext2fs, which parses an IEC or SI multiplier: a plain
+ * number, or a string such as `"64Mi"`, `"1G"` or `"512k"`.
+ */
+export type Size = number | string;
+
+/** A source of content, applied to the image in the order given. */
+export type Layer =
+    /** `-d`: add a directory and its contents */
+    | { type: "directory"; path: string; target?: string }
+    /** `-a`: add the contents of an (uncompressed) tar archive */
+    | { type: "tarball"; path: string; target?: string }
+    /** `-D`: create/fix up inodes described by a device table file */
+    | { type: "devtable"; path: string; target?: string };
+
+export interface Genext2fsOptions {
+    /** `-x`: use this image as a starting point instead of an empty one. */
+    startingImage?: string;
+
+    /** `-B`: size of a filesystem block in bytes. Defaults to 1024. */
+    blockSize?: BlockSize;
+
+    /**
+     * `-b`: size of the image in blocks. Computed from the content when
+     * omitted.
+     */
+    sizeInBlocks?: Size;
+
+    /** `-N`: minimum number of inodes. */
+    numberOfInodes?: Size;
+
+    /** `-i`: bytes per inode, used to derive the inode count from the size. */
+    bytesPerInode?: Size;
+
+    /**
+     * `-r`: grow the computed size and inode count by this much, as an absolute
+     * number of blocks or a percentage, e.g. `"+10%"` or `"+1024"`.
+     */
+    readjustment?: string;
+
+    /** `-L`: volume label. */
+    volumeLabel?: string;
+
+    /**
+     * `-m`: blocks to reserve, as a percentage of the image size. Reserving 0
+     * also skips creation of `lost+found`.
+     */
+    reservedPercentage?: number;
+
+    /** `-o`: value for the creator OS field of the superblock. */
+    creatorOs?: CreatorOs;
+
+    /**
+     * `-g`: generate a block map for each of these paths. The maps are written
+     * to the *current working directory* as `<path>.blk`, with slashes replaced
+     * by underscores.
+     */
+    blockMap?: string[];
+
+    /** `-e`: fill unallocated blocks with this byte value. */
+    fillValue?: number;
+
+    /** `-z`: make files with holes. */
+    allowHoles?: boolean;
+
+    /**
+     * `-f`: use a timestamp of 0 for inode and filesystem creation instead of
+     * the present, making the output reproducible. Setting the
+     * `SOURCE_DATE_EPOCH` environment variable achieves the same with a chosen
+     * timestamp.
+     */
+    faketime?: boolean;
+
+    /** `-q`: squash both ownership and permissions, owning everything by this uid. */
+    squash?: number;
+
+    /** `-U`: squash ownership of added inodes, owning them all by this uid. */
+    squashUids?: number;
+
+    /** `-P`: squash permissions of added inodes, analogous to `umask 077`. */
+    squashPerms?: boolean;
+
+    /** `-v`: print the resulting filesystem structure to `stdout`. */
+    verbose?: boolean;
+}
+
+export interface ImageOptions extends Genext2fsOptions {
+    /** Content sources, applied in order. */
+    layers?: Layer[];
+
+    /**
+     * Retry with a slightly larger explicit size when xgenext2fs runs out of
+     * blocks part way through, which its own size estimate makes it do for some
+     * archives. Both the estimate and the growth are deterministic, so the
+     * resulting image is reproducible. Defaults to `true`, and does not apply
+     * when `sizeInBlocks` or `startingImage` is set.
+     */
+    autoSize?: boolean;
+}
+
+const layerFlags: Record<Layer["type"], string> = {
+    directory: "-d",
+    tarball: "-a",
+    devtable: "-D",
+};
+
+/**
+ * xgenext2fs splits a layer argument on its first colon, so neither the source
+ * path nor the target path may contain one.
+ */
+const layerSpec = (layer: Layer): string => {
+    if (layer.path.includes(":")) {
+        throw new Error(
+            `layer path must not contain ":" (xgenext2fs uses it to separate the target path): ${layer.path}`,
+        );
+    }
+    if (layer.target === undefined) {
+        return layer.path;
+    }
+    if (layer.target.includes(":")) {
+        throw new Error(`layer target must not contain ":": ${layer.target}`);
+    }
+    return `${layer.path}:${layer.target}`;
+};
+
+/**
+ * Build the xgenext2fs argv (without the program name) for the given options
+ * and output image path.
+ */
+export const buildArgs = (
+    output: string,
+    options: ImageOptions = {},
+): string[] => {
+    if (output === "-") {
+        throw new Error(
+            'writing the image to stdout ("-") is not supported; pass a file path',
+        );
+    }
+
+    const args: string[] = [];
+    const push = (flag: string, value?: Size) => {
+        args.push(flag);
+        if (value !== undefined) {
+            args.push(String(value));
+        }
+    };
+
+    if (options.startingImage !== undefined) {
+        push("-x", options.startingImage);
+    }
+    for (const layer of options.layers ?? []) {
+        push(layerFlags[layer.type], layerSpec(layer));
+    }
+    if (options.blockSize !== undefined) {
+        push("-B", options.blockSize);
+    }
+    if (options.sizeInBlocks !== undefined) {
+        push("-b", options.sizeInBlocks);
+    }
+    if (options.numberOfInodes !== undefined) {
+        push("-N", options.numberOfInodes);
+    }
+    if (options.bytesPerInode !== undefined) {
+        push("-i", options.bytesPerInode);
+    }
+    if (options.readjustment !== undefined) {
+        push("-r", options.readjustment);
+    }
+    if (options.volumeLabel !== undefined) {
+        push("-L", options.volumeLabel);
+    }
+    if (options.reservedPercentage !== undefined) {
+        push("-m", options.reservedPercentage);
+    }
+    if (options.creatorOs !== undefined) {
+        push("-o", options.creatorOs);
+    }
+    for (const path of options.blockMap ?? []) {
+        push("-g", path);
+    }
+    if (options.fillValue !== undefined) {
+        push("-e", options.fillValue);
+    }
+    if (options.allowHoles) {
+        push("-z");
+    }
+    if (options.faketime) {
+        push("-f");
+    }
+    if (options.squash !== undefined) {
+        push("-q", options.squash);
+    }
+    if (options.squashUids !== undefined) {
+        push("-U", options.squashUids);
+    }
+    if (options.squashPerms) {
+        push("-P");
+    }
+    if (options.verbose) {
+        push("-v");
+    }
+
+    args.push(output);
+    return args;
+};

--- a/packages/bindings/genext2fs/src/xgenext2fs.h
+++ b/packages/bindings/genext2fs/src/xgenext2fs.h
@@ -1,0 +1,41 @@
+/*
+ * Library entry point around the unmodified xgenext2fs CLI source.
+ * See xgenext2fs_lib.c for how the CLI is turned into a callable function.
+ */
+
+#ifndef DEROLL_XGENEXT2FS_H
+#define DEROLL_XGENEXT2FS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct xge_result {
+    /* exit status the CLI would have returned: 0 on success */
+    int status;
+    /* NUL-terminated capture of everything written to stdout/stderr, or NULL */
+    char *out;
+    char *err;
+} xge_result;
+
+/*
+ * Run xgenext2fs with `argv` (argv[0] must be the program name, argv[argc] must
+ * be NULL) and capture its output into `res`. Returns res->status.
+ *
+ * NOT reentrant: xgenext2fs keeps parser state in globals and reports errors by
+ * calling exit(), so callers must serialize invocations. The addon holds a mutex
+ * around this call.
+ */
+int xge_run(int argc, char **argv, xge_result *res);
+
+/* Release the buffers owned by a result. Safe to call on a zeroed result. */
+void xge_result_free(xge_result *res);
+
+/* The xgenext2fs version this was built against, e.g. "1.5.6". */
+const char *xge_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEROLL_XGENEXT2FS_H */

--- a/packages/bindings/genext2fs/src/xgenext2fs_lib.c
+++ b/packages/bindings/genext2fs/src/xgenext2fs_lib.c
@@ -1,0 +1,213 @@
+/*
+ * Turns the xgenext2fs CLI into a callable library function without patching a
+ * single line of deps/genext2fs/xgenext2fs.c.
+ *
+ * xgenext2fs is a normal command line program: it parses argv with getopt_long,
+ * writes progress to stderr, dumps `--verbose` output to stdout, and reports
+ * every error by calling exit(). None of that is usable from a long-lived Node
+ * process, so this translation unit textually includes the upstream source with
+ * three redirections in place:
+ *
+ *   main()   -> xgenext2fs_main(), so we can call it with our own argv
+ *   exit()   -> longjmp() back into xge_run(), so failures unwind instead of
+ *               taking the whole process down
+ *   stdout/stderr (and the printf family) -> temporary files, so the CLI's
+ *               diagnostics become strings we can hand back to JavaScript
+ *
+ * The redirections are macros, so every system header xgenext2fs.c pulls in has
+ * to be included *before* they are defined -- otherwise the `exit` macro would
+ * rewrite the prototype in <stdlib.h>. The block below mirrors the include list
+ * at the top of xgenext2fs.c; xgenext2fs.c's own #includes then no-op on their
+ * header guards.
+ *
+ * Limitations that follow from this approach and are handled by the callers:
+ *   - not reentrant (getopt state, `blocksize` and `app_name` are globals), so
+ *     the addon serializes calls with a mutex;
+ *   - longjmp()ing out of a failed run leaks whatever the CLI had allocated at
+ *     that point. Errors are expected to be rare and the leak is bounded by one
+ *     partially built filesystem, so this is preferred over fork()ing.
+ */
+
+#include <signal.h>
+
+#include <config.h>
+
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <libgen.h>
+#include <limits.h>
+#include <locale.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#if MAJOR_IN_MKDEV
+#include <sys/mkdev.h>
+#elif MAJOR_IN_SYSMACROS
+#include <sys/sysmacros.h>
+#endif
+
+#include <archive.h>
+#include <archive_entry.h>
+
+#include <assert.h>
+#include <setjmp.h>
+
+#include "xgenext2fs.h"
+
+/* ------------------------------------------------------------------------- */
+
+static jmp_buf xge_jmp;
+static FILE *xge_out;
+static FILE *xge_err;
+
+#if defined(__GNUC__) || defined(__clang__)
+static void xge_exit(int status) __attribute__((noreturn));
+#else
+static void xge_exit(int status);
+#endif
+
+/* Redirect the CLI's process-wide side effects at the whole included source. */
+#undef stdout
+#undef stderr
+#define stdout xge_out
+#define stderr xge_err
+#define exit(status) xge_exit(status)
+#define printf(...) fprintf(stdout, __VA_ARGS__)
+#define putchar(c) fputc((c), stdout)
+#define main xgenext2fs_main
+
+#include "xgenext2fs.c"
+
+#undef main
+#undef putchar
+#undef printf
+#undef exit
+#undef stderr
+#undef stdout
+
+/*
+ * exit(0) has to survive the round trip through longjmp(), which turns a value
+ * of 0 into 1, so statuses are biased by one on the way out.
+ */
+static void
+xge_exit(int status)
+{
+    longjmp(xge_jmp, status + 1);
+}
+
+/* ------------------------------------------------------------------------- */
+
+/* Read a capture stream back into a NUL-terminated heap buffer. */
+static char *
+xge_drain(FILE *fh)
+{
+    long size;
+    char *buf;
+    size_t got;
+
+    if (fh == NULL)
+        return NULL;
+    if (fflush(fh) != 0 || fseek(fh, 0, SEEK_END) != 0)
+        return NULL;
+    if ((size = ftell(fh)) <= 0)
+        return NULL;
+    if (fseek(fh, 0, SEEK_SET) != 0)
+        return NULL;
+    if ((buf = malloc((size_t)size + 1)) == NULL)
+        return NULL;
+    got = fread(buf, 1, (size_t)size, fh);
+    buf[got] = '\0';
+    return buf;
+}
+
+/*
+ * Put the globals xgenext2fs relies on back into the state they have at process
+ * start, so a second call behaves like a fresh process.
+ */
+static void
+xge_reset_globals(void)
+{
+    /* file scope state of xgenext2fs.c */
+    blocksize = 1024;
+    app_name = NULL;
+
+    /* getopt(3) scan state */
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) ||       \
+    defined(__NetBSD__) || defined(__DragonFly__)
+    optreset = 1;
+    optind = 1;
+#else
+    /* glibc and musl reinitialize completely when optind is 0 */
+    optind = 0;
+#endif
+    opterr = 1;
+    optopt = '?';
+}
+
+int
+xge_run(int argc, char **argv, xge_result *res)
+{
+    int jumped;
+
+    res->status = 0;
+    res->out = NULL;
+    res->err = NULL;
+
+    xge_out = tmpfile();
+    xge_err = tmpfile();
+    if (xge_out == NULL || xge_err == NULL) {
+        if (xge_out != NULL)
+            fclose(xge_out);
+        if (xge_err != NULL)
+            fclose(xge_err);
+        xge_out = xge_err = NULL;
+        res->status = -1;
+        res->err = strdup("could not allocate temporary files for output capture");
+        return res->status;
+    }
+
+    xge_reset_globals();
+
+    if ((jumped = setjmp(xge_jmp)) != 0)
+        res->status = jumped - 1; /* reached through the exit() redirection */
+    else
+        res->status = xgenext2fs_main(argc, argv);
+
+    res->out = xge_drain(xge_out);
+    res->err = xge_drain(xge_err);
+
+    fclose(xge_out);
+    fclose(xge_err);
+    xge_out = xge_err = NULL;
+
+    return res->status;
+}
+
+void
+xge_result_free(xge_result *res)
+{
+    if (res == NULL)
+        return;
+    free(res->out);
+    free(res->err);
+    res->out = NULL;
+    res->err = NULL;
+}
+
+const char *
+xge_version(void)
+{
+    return VERSION;
+}

--- a/packages/bindings/genext2fs/tsconfig.json
+++ b/packages/bindings/genext2fs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "@deroll/tsconfig/base.json",
+    "compilerOptions": {
+        "types": ["node"]
+    },
+    "include": ["src"],
+    "exclude": ["dist", "build", "node_modules"]
+}

--- a/packages/bindings/genext2fs/tsup.config.ts
+++ b/packages/bindings/genext2fs/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    clean: true,
+    dts: true,
+    entry: ["src/index.ts"],
+    format: ["cjs", "esm"],
+    sourcemap: true,
+    // __dirname in the ESM output, used to locate the native addon relative to
+    // the package root
+    shims: true,
+});


### PR DESCRIPTION
Binds [cartesi/genext2fs](https://github.com/cartesi/genext2fs) to Node.js as an N-API addon, so a tar archive can be turned into an ext2 drive image from inside a Node process instead of shelling out to a container or an installed CLI.

```ts
import { tarToExt2 } from "@deroll/genext2fs";

await tarToExt2("rootfs.tar", "rootfs.ext2", { blockSize: 4096, faketime: true });
```

## Approach

`xgenext2fs` is a command line program, not a library: a single 100 KB C file that parses `argv`, prints to `stderr` and calls `exit()` on every error. Rather than fork it, both upstream projects are vendored as **git submodules** and compiled unmodified by `node-gyp`:

| Submodule | Pin | Why |
| --- | --- | --- |
| `deps/genext2fs` | `v1.5.6` | the generator itself |
| `deps/libarchive` | `v3.8.9` | the Cartesi fork's `add2fs_from_tarball()` calls `archive_read_*` unconditionally, so libarchive is a hard requirement (the README's "builtin tarball parser" note is stale) |

Three pieces make that work:

- **`src/xgenext2fs_lib.c`** textually includes `xgenext2fs.c` with `main` renamed, `exit()` redirected through `longjmp()`, and `stdout`/`stderr` redirected into temporary files — which is what turns the CLI into a callable function whose failures unwind and whose diagnostics come back as strings. Upstream is not patched at all.
- **`src/libarchive_formats.c`** narrows `archive_read_support_format_all`/`support_filter_all` to tar + none, so only **16 of libarchive's 217** translation units are compiled and the addon links against nothing but libc. No zlib/bz2/lzma, no system libarchive; gzip is inflated in JS instead.
- **`config/`** holds hand-written replacements for the two generated `config.h` files, since `node-gyp` cannot run `./configure`. POSIX features are asserted directly, with `__APPLE__`/`__linux__` branches for the few that genuinely differ.

Submodules over copying the sources: provenance is exact, bumps are a `git checkout`, and it matches the existing `@deroll/cmio` pattern. The published tarball carries only the files actually compiled.

Because xgenext2fs keeps parser state in globals and `chdir()`s while reading directory layers, calls are serialized behind a mutex in the addon; async calls still generate off the main thread.

## API

Four functions:

- `tarToExt2(tar, output, options?)` — the main use case, archive as a path or bytes, gzip inflated transparently
- `createImage(output, options?)` — images assembled from several layers (`tarball` / `directory` / `devtable`, each optionally at a path inside the image)
- `tarToExt2Sync` / `createImageSync` — the same work on the calling thread

There is deliberately **no raw-argv escape hatch**: of xgenext2fs' 22 long options, 19 map onto `ImageOptions` or a layer type, `--version` is the exported `version`, and `--help` is meaningless in a library. Auditing that list also corrected `CreatorOs` — `masix` is not recognized by `lookup_creator_os()` and silently falls back to Linux, `GNU` is an accepted alias for `hurd`, and a raw number is accepted for an OS the tool has no name for.

Errors reject with the tool's own diagnostic, carrying `status`, `stdout` and `stderr`.

## Two things worth a look before merging

**License.** xgenext2fs is GPL-2.0-**only** (not "or later") and this package compiles it in, so `@deroll/genext2fs` is GPL-2.0-only — unlike every other package in the repo, which are Apache-2.0. Called out in `package.json`, the package README, the docs and `CLAUDE.md`, but whether that belongs in this monorepo is a call for a human.

**Upstream sizing bug.** With no `-b`, xgenext2fs under-estimates the image by 3–13 blocks for some archives and dies mid-build with `couldn't allocate a block (no free space)`. The standalone CLI does the same — which is why Cartesi's tooling always passes an explicit `-b`. `createImage` absorbs it: on that specific failure it retries with a size derived from the failed attempt (the partial file is truncated to `blocks * blockSize`, so the estimate is readable from disk). Deterministic, so images stay reproducible. `autoSize: false` opts out and `sizeInBlocks` pins it.

## Also in this PR

- Release workflow: a `genext2fs-prebuild` matrix (linux/macOS × x64/arm64) gated on the same "is this version already on npm" check as `cmio`/`cm`, with prebuilds collected into the package before publish. Unlike its siblings this job needs no system packages.
- Docs: a `genext2fs` section (intro, API, options) plus top-nav and sidebar entries.
- Root README: a note that the native bindings need `--recurse-submodules`.
- A changeset, and the package registered in `.changeset/pre.json`.

## Verification

19 tests pass — e2fsck-clean images, byte-identical output across runs with `faketime`, gzip and `Uint8Array` input matching path input, the full option surface in a single call, concurrent conversions, `autoSize` growth versus `autoSize: false`, error `status`/`stderr`, and the addon staying usable after a failed run. I also packed the tarball, extracted it into a clean directory and confirmed the from-source build works end to end, which is the real check on the `files` list and the submodule strategy. `bun run lint`, `bun run build` and `bun run test` are green across the workspace, and the docs site builds with the twoslash snippets typechecked.

Not included: an entry in `apps/examples` — happy to add one if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ516LsVnnu4ySXKkXsNbB