### PR TITLE
Upgrade to libcmt 0.18.0 and machine-guest-tools v0.18.0

### DIFF
--- a/.changeset/cmio-libcmt-0-18.md
+++ b/.changeset/cmio-libcmt-0-18.md
@@ -1,0 +1,12 @@
+---
+"@deroll/cmio": minor
+"@deroll/create-app": patch
+---
+
+Target libcmt 0.18.0 (machine-guest-tools `v0.18.0`). The binding's public JavaScript API is unchanged; the upgrade is internal and to the build:
+
+- `HTIF_YIELD_REASON_ADVANCE`/`HTIF_YIELD_REASON_INSPECT` were renamed to `HTIF_YIELD_REASON_ADVANCE_STATE`/`HTIF_YIELD_REASON_INSPECT_STATE` in libcmt; the addon's request dispatch in `finish()` follows the rename.
+- libcmt now bundles the `cmio` ioctl ABI (`include/libcmt/ioctl.h`) instead of including `<linux/cartesi/cmio.h>`, so cross-building the linux-riscv64 prebuild no longer needs the Cartesi Linux headers. The `linux-libc-dev-riscv64-cross` install was dropped from CI, the release workflow and `test/machine/Dockerfile.prebuild`.
+- The mock IO driver writes the outputs Merkle root to `<input>.outputs_merkle_root<ext>` (was `<input>.outputs_root_hash<ext>`), matching the terminology used by rollups-contracts and the machine emulator. Only affects test harnesses that read that file directly.
+- The riscv64 end-to-end machine test now boots the v0.21.0 Cartesi kernel (6.5.13-ctsi-2) with machine-guest-tools `v0.18.0`, matching what the submodule targets.
+- `create-app`'s generated Dockerfile installs machine-guest-tools 0.18.0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,8 @@ concurrency:
     group: ci-${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
-# LINUX_*: used by the riscv64 cross-build. Keep in sync with the
-# machine-guest-tools submodule (its Makefile LINUX_HEADERS_* variables).
 # CARTESI_MACHINE_VERSION: emulator distribution cm's addon links against.
 env:
-    LINUX_IMAGE_VERSION: v0.21.0
-    LINUX_VERSION: 6.5.13-ctsi-2
     CARTESI_MACHINE_VERSION: 0.21.0
 
 jobs:
@@ -98,13 +94,12 @@ jobs:
             # bun (not npm) — the workspace uses bun's `catalog:` protocol.
             - run: bun install --frozen-lockfile
 
-            - name: Install riscv64 cross toolchain and Cartesi Linux headers
+            # libcmt bundles the `cmio` ioctl ABI since machine-guest-tools
+            # 0.18.0, so the Cartesi Linux headers are no longer needed here.
+            - name: Install riscv64 cross toolchain
               run: |
                   sudo apt-get update
                   sudo apt-get install -y --no-install-recommends gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
-                  wget -O /tmp/linux-libc-dev.deb \
-                    "https://github.com/cartesi/machine-linux-image/releases/download/${LINUX_IMAGE_VERSION}/linux-libc-dev-riscv64-cross-${LINUX_VERSION}-${LINUX_IMAGE_VERSION}.deb"
-                  sudo apt-get install -y --allow-downgrades /tmp/linux-libc-dev.deb
 
             - name: Cross-build libcmt (real IO driver)
               working-directory: packages/bindings/cmio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,8 @@ permissions:
     pull-requests: write
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-# LINUX_*: used by the riscv64 cross-build. Keep in sync with the
-# machine-guest-tools submodule (its Makefile LINUX_HEADERS_* variables).
 # CARTESI_MACHINE_VERSION: emulator distribution cm's addon links against.
 env:
-    LINUX_IMAGE_VERSION: v0.21.0
-    LINUX_VERSION: 6.5.13-ctsi-2
     CARTESI_MACHINE_VERSION: 0.21.0
 
 jobs:
@@ -173,13 +169,12 @@ jobs:
                   wget -O /tmp/machine-emulator.deb "https://github.com/cartesi/machine-emulator/releases/download/v${CARTESI_MACHINE_VERSION}/machine-emulator_$(dpkg --print-architecture).deb"
                   sudo apt-get update && sudo apt-get install -y /tmp/machine-emulator.deb
             - run: bun install --frozen-lockfile
-            - name: Install riscv64 cross toolchain and Cartesi Linux headers
+            # libcmt bundles the `cmio` ioctl ABI since machine-guest-tools
+            # 0.18.0, so the Cartesi Linux headers are no longer needed here.
+            - name: Install riscv64 cross toolchain
               run: |
                   sudo apt-get update
                   sudo apt-get install -y --no-install-recommends gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
-                  wget -O /tmp/linux-libc-dev.deb \
-                    "https://github.com/cartesi/machine-linux-image/releases/download/${LINUX_IMAGE_VERSION}/linux-libc-dev-riscv64-cross-${LINUX_VERSION}-${LINUX_IMAGE_VERSION}.deb"
-                  sudo apt-get install -y --allow-downgrades /tmp/linux-libc-dev.deb
             - name: Cross-build libcmt (real IO driver)
               working-directory: packages/bindings/cmio
               run: make -C deps/machine-guest-tools/sys-utils/libcmt libcmt TOOLCHAIN_PREFIX=riscv64-linux-gnu-

--- a/apps/docs/pages/cmio/guide/cartesi-machine.mdx
+++ b/apps/docs/pages/cmio/guide/cartesi-machine.mdx
@@ -11,7 +11,7 @@ A minimal Dockerfile for a machine rootfs:
 
 ```dockerfile
 FROM --platform=linux/riscv64 debian:trixie-slim
-ARG GUEST_TOOLS_VERSION=v0.17.2
+ARG GUEST_TOOLS_VERSION=v0.18.0
 ADD https://github.com/cartesi/machine-guest-tools/releases/download/${GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb /tmp/
 RUN apt-get update \
     && apt-get install -y --no-install-recommends nodejs /tmp/machine-guest-tools_riscv64.deb \

--- a/packages/app/create-app/src/dockerfile.ts
+++ b/packages/app/create-app/src/dockerfile.ts
@@ -66,8 +66,8 @@ export const dockerfile = (options: DockerfileOptions): string => {
 # This enforces that the packages downloaded from the repositories are the same
 # for the defined date, no matter when the image is built.
 ARG APT_UPDATE_SNAPSHOT=${aptSnapshot}
-ARG MACHINE_GUEST_TOOLS_VERSION=0.17.2
-ARG MACHINE_GUEST_TOOLS_SHA256SUM=c077573dbcf0cdc146adf14b480bfe454ca63aa4d3e8408c5487f550a5b77a41
+ARG MACHINE_GUEST_TOOLS_VERSION=0.18.0
+ARG MACHINE_GUEST_TOOLS_SHA256SUM=204d4260defd68e11b957ae1f1b511b6c2c74345c918748be06f592733b72dcd
 
 ################################################################################
 # riscv64 base stage

--- a/packages/bindings/cmio/README.md
+++ b/packages/bindings/cmio/README.md
@@ -104,7 +104,7 @@ On riscv64 the addon does not compile libcmt; it links the static library instal
 
 ### Prebuilds
 
-`npm run prebuild` produces `prebuilds/<platform>-<arch>/` via prebuildify; `node-gyp-build` picks them up at install time so consumers need no toolchain. Cross-building the riscv64 prebuild requires the riscv64 cross toolchain and a libcmt built with the Cartesi Linux headers — see `.github/workflows/build.yml`.
+`npm run prebuild` produces `prebuilds/<platform>-<arch>/` via prebuildify; `node-gyp-build` picks them up at install time so consumers need no toolchain. Cross-building the riscv64 prebuild requires the riscv64 cross toolchain and a libcmt cross-built from the submodule (`make -C deps/machine-guest-tools/sys-utils/libcmt libcmt TOOLCHAIN_PREFIX=riscv64-linux-gnu-`); since libcmt 0.18.0 bundles the `cmio` ioctl ABI, the Cartesi Linux headers are no longer needed. See `.github/workflows/ci.yml`.
 
 ## Releasing
 

--- a/packages/bindings/cmio/src/addon.cc
+++ b/packages/bindings/cmio/src/addon.cc
@@ -134,7 +134,7 @@ Napi::Value Rollup::Finish(const Napi::CallbackInfo &info) {
         return env.Undefined();
     }
     Napi::Object request = Napi::Object::New(env);
-    if (finish.next_request_type == HTIF_YIELD_REASON_ADVANCE) {
+    if (finish.next_request_type == HTIF_YIELD_REASON_ADVANCE_STATE) {
         cmt_rollup_advance_t advance{};
         rc = cmt_rollup_read_advance_state(&rollup_, &advance);
         if (rc < 0) {

--- a/packages/bindings/cmio/test/machine/Dockerfile.prebuild
+++ b/packages/bindings/cmio/test/machine/Dockerfile.prebuild
@@ -1,22 +1,17 @@
 # Cross-builds the linux-riscv64 prebuild, mirroring the CI prebuild-riscv64
-# job (see .github/workflows/build.yml). Build from the repository root:
+# job (see .github/workflows/release.yml). Build from the repository root:
 #
 #   docker build --platform linux/amd64 -f test/machine/Dockerfile.prebuild \
 #     --target export --output type=local,dest=prebuilds .
 
 FROM node:22-bookworm AS build
 
-ARG LINUX_IMAGE_VERSION=v0.20.0
-ARG LINUX_VERSION=6.5.13-ctsi-1
-
+# libcmt bundles the `cmio` ioctl ABI since machine-guest-tools 0.18.0
+# (include/libcmt/ioctl.h), so the Cartesi Linux headers are no longer needed
+# to cross-build it.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        gcc-riscv64-linux-gnu g++-riscv64-linux-gnu wget ca-certificates \
+        gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
     && rm -rf /var/lib/apt/lists/*
-
-RUN wget -q -O /tmp/linux-libc-dev.deb \
-        "https://github.com/cartesi/machine-linux-image/releases/download/${LINUX_IMAGE_VERSION}/linux-libc-dev-riscv64-cross-${LINUX_VERSION}-${LINUX_IMAGE_VERSION}.deb" \
-    && dpkg -i /tmp/linux-libc-dev.deb \
-    && rm /tmp/linux-libc-dev.deb
 
 WORKDIR /work
 COPY . .

--- a/packages/bindings/cmio/test/machine/Dockerfile.rootfs
+++ b/packages/bindings/cmio/test/machine/Dockerfile.rootfs
@@ -8,7 +8,7 @@
 
 FROM debian:trixie-slim
 
-ARG GUEST_TOOLS_VERSION=v0.17.2
+ARG GUEST_TOOLS_VERSION=v0.18.0
 
 ADD https://github.com/cartesi/machine-guest-tools/releases/download/${GUEST_TOOLS_VERSION}/machine-guest-tools_riscv64.deb /tmp/machine-guest-tools.deb
 

--- a/packages/bindings/cmio/test/machine/run.sh
+++ b/packages/bindings/cmio/test/machine/run.sh
@@ -24,9 +24,9 @@ CARTESI_MACHINE=${CARTESI_MACHINE:-cartesi-machine}
 WORK=test/machine/work
 mkdir -p "$WORK"
 
-LINUX_IMAGE_VERSION=v0.20.0
-LINUX_VERSION=6.5.13-ctsi-1
-GUEST_TOOLS_VERSION=v0.17.2
+LINUX_IMAGE_VERSION=v0.21.0
+LINUX_VERSION=6.5.13-ctsi-2
+GUEST_TOOLS_VERSION=v0.18.0
 
 # 1. Cartesi kernel for the emulator
 KERNEL="$WORK/linux-${LINUX_VERSION}-${LINUX_IMAGE_VERSION}.bin"
@@ -40,8 +40,6 @@ fi
 if [ -z "${SKIP_PREBUILD:-}" ]; then
     echo "==> cross-building linux-riscv64 prebuild"
     docker build --platform linux/amd64 \
-        --build-arg LINUX_IMAGE_VERSION="$LINUX_IMAGE_VERSION" \
-        --build-arg LINUX_VERSION="$LINUX_VERSION" \
         -f test/machine/Dockerfile.prebuild \
         --target export --output type=local,dest=prebuilds .
 fi


### PR DESCRIPTION
## Summary
This PR upgrades the cmio binding and related tooling to target libcmt 0.18.0 (bundled with machine-guest-tools v0.18.0). The upgrade simplifies the build process by removing the dependency on Cartesi Linux headers, as libcmt now bundles the `cmio` ioctl ABI internally.

## Key Changes

- **Updated addon code** (`addon.cc`): Changed `HTIF_YIELD_REASON_ADVANCE` to `HTIF_YIELD_REASON_ADVANCE_STATE` to match the renamed constant in libcmt 0.18.0
- **Simplified build process**: Removed the need to download and install `linux-libc-dev-riscv64-cross` package from CI/release workflows and Docker builds, since libcmt now bundles the required ioctl definitions
- **Updated machine-guest-tools submodule**: Bumped to the commit that includes v0.18.0
- **Updated test infrastructure**: 
  - Bumped Cartesi kernel to v0.21.0 (6.5.13-ctsi-2) and guest tools to v0.18.0 in `run.sh`
  - Updated Dockerfile templates to use v0.18.0
  - Removed build arguments from `Dockerfile.prebuild` that are no longer needed
- **Updated documentation**: Corrected workflow references and updated version numbers in README and guides
- **Updated generated Dockerfile**: `create-app` now generates Dockerfiles that install machine-guest-tools 0.18.0 with the correct SHA256 checksum

## Implementation Details

The main source code change is in the addon's request dispatch logic, which now uses the renamed `HTIF_YIELD_REASON_ADVANCE_STATE` constant. All other changes are build configuration and documentation updates that reflect the simplified dependency chain enabled by libcmt's bundled ioctl definitions.

https://claude.ai/code/session_01BxKFy2hRatDS7To3g5BnD4