### PR TITLE
refactor(core,app)!: align with @cartesi/rollup, drop the HTTP-era surface

### DIFF
--- a/.changeset/core-app-align-with-cartesi-rollup.md
+++ b/.changeset/core-app-align-with-cartesi-rollup.md
@@ -13,6 +13,20 @@ Now that `@cartesi/rollup` owns the protocol vocabulary, `@deroll/core` keeps on
 
 Removed along the way: `RollupAdvanceRequest`, `RollupInspectRequest`, `RequestType`, `RequestData`, `RequestMetadata`, `NoticeResponse`, `ReportResponse` and `VoucherResponse` — leftovers of the Rollup HTTP Server transport, with no consumers since it was replaced.
 
+**Breaking: advance handlers return a boolean.** `"accept"`/`"reject"` were the `status` field of the Rollup HTTP Server's `/finish` request body, passed through verbatim by deroll v1 — the last piece of that transport's vocabulary left in the API. Handlers now return `true` to accept an input or `false` to decline it and pass it to the next handler, matching `finish({ accept })` in the binding. The words were also misleading in a handler chain: returning `"reject"` never rejected the input, it only declined it, and the input is rejected only when no handler accepted.
+
+`RequestHandlerResult` is now `boolean`, deliberately without `void`: `Rollup.run` in the binding accepts a request unless a handler returns `false`, whereas deroll rejects unless a handler opts in, so a handler that falls off its end must be a type error rather than a silent accept.
+
+```diff
+-app.addAdvanceHandler(async (data) => {
+-    if (!isMine(data)) return "reject";
+-    return "accept";
++app.addAdvanceHandler((request) => {
++    if (!isMine(request)) return false;
++    return true;
+ });
+```
+
 **Breaking: the advance request is flat.** `AdvanceRequestData`/`AdvanceRequestMetadata` are replaced by `AdvanceRequest`, which carries the metadata fields directly alongside `payload` and a `type: "advance"` discriminant. `InspectRequestData` becomes `InspectRequest`.
 
 ```diff

--- a/.changeset/core-app-align-with-cartesi-rollup.md
+++ b/.changeset/core-app-align-with-cartesi-rollup.md
@@ -1,0 +1,44 @@
+---
+"@deroll/core": minor
+"@deroll/app": minor
+"@deroll/router": minor
+"@deroll/wallet": minor
+---
+
+Stop restating the rollup protocol in `@deroll/core`, and align `@deroll/app` with the binding it wraps.
+
+Now that `@cartesi/rollup` owns the protocol vocabulary, `@deroll/core` keeps only what is genuinely deroll's — the composition contract that lets independently authored handlers share one rollup loop — and re-exports the rest. `@deroll/app` remains the multi-handler loop with reject-by-default semantics, but it no longer wraps a synchronous binding in an asynchronous facade.
+
+**Breaking: the protocol types come from `@cartesi/rollup`.** `@deroll/core` re-exports `AdvanceRequest`, `InspectRequest`, `RollupRequest`, `Voucher`, `DelegateCallVoucher`, `BytesLike`, `AddressLike`, `U256Like` and `Hex` instead of declaring its own copies, so the two can never drift. `@cartesi/rollup` is a **peer dependency** of `@deroll/core`: the rollup device allows only one open handle per process, so the dependency tree must resolve to a single copy of the binding. `@deroll/core` no longer depends on `viem`.
+
+Removed along the way: `RollupAdvanceRequest`, `RollupInspectRequest`, `RequestType`, `RequestData`, `RequestMetadata`, `NoticeResponse`, `ReportResponse` and `VoucherResponse` — leftovers of the Rollup HTTP Server transport, with no consumers since it was replaced.
+
+**Breaking: the advance request is flat.** `AdvanceRequestData`/`AdvanceRequestMetadata` are replaced by `AdvanceRequest`, which carries the metadata fields directly alongside `payload` and a `type: "advance"` discriminant. `InspectRequestData` becomes `InspectRequest`.
+
+```diff
+-app.addAdvanceHandler(async ({ metadata, payload }) => {
+-    console.log(metadata.msgSender);
++app.addAdvanceHandler(({ msgSender, payload }) => {
++    console.log(msgSender);
+     return "accept";
+ });
+```
+
+**Breaking: outputs are synchronous, and notice/report payloads are no longer wrapped.** Emitting an output is a device write, not I/O the event loop can interleave with — `finish` pauses the entire guest — so the `App` methods no longer return promises. The `Notice`, `Report` and `Exception` wrapper types are gone; vouchers keep their object argument, since they carry a `destination` and an optional `value` besides the payload.
+
+```diff
+-const id = await app.createNotice({ payload: stringToHex("hello") });
+-await app.createReport({ payload: stringToHex("hello") });
+-const id = await app.createVoucher({ destination, payload });
++const id = app.createNotice(stringToHex("hello"));
++app.createReport(stringToHex("hello"));
++const id = app.createVoucher({ destination, payload });
+```
+
+Handlers may still be `async` — they are awaited — but they no longer have to be. `@deroll/wallet`'s and `@deroll/router`'s handlers are now synchronous.
+
+**Breaking: a handler exception rejects the request and is reported.** Previously an exception was written to `stderr` and the next handler ran anyway, which could let a later handler write state on top of a partially applied one — and left the failure invisible from outside the machine. Now the input is rejected immediately, the remaining handlers are skipped, and the error is emitted as a report, which survives the rejection. Applications that relied on throwing to fall through to another handler should return `"reject"` instead.
+
+**`registerException` is now part of the `App` interface.** `NativeApp` always implemented it, but it was missing from the interface that `createApp` returns, so it was unreachable through the public API.
+
+`Router.handler` now reads its query straight out of the request `Buffer` instead of round-tripping it through viem's `toBytes`, which only decoded correctly by accident.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The four outputs a backend can emit: **notices** (verifiable event logs), **repo
 bun + Turborepo workspace. Workspaces are grouped by pillar: `packages/*/*` (glob) and `apps/*`. The three pillars are **App** (`packages/app/*`), **Bindings** (`packages/bindings/*`), and **Explorer** (`packages/explorer/*`). `apps/*` are private (docs + examples + the explorer site).
 
 App pillar — `packages/app/*`:
-- **`packages/app/core`** (`@deroll/core`) — shared, **hand-authored** types (`src/types.ts`, `src/index.ts`; depends only on `viem`). Defines the `App` interface, `AppOptions`, and the request/output types (camelCase, `bigint` metadata, `Buffer` request payloads; outputs use viem `Hex`/`Uint8Array`). No runtime logic, no codegen; everything else depends on this.
+- **`packages/app/core`** (`@deroll/core`) — the composition contract (`src/types.ts`, `src/index.ts`). Defines the `App` interface, `AppOptions`, `AdvanceRequestHandler`, `InspectRequestHandler` and `RequestHandlerResult`. It does **not** redeclare the rollup protocol vocabulary: the request and output shapes (`AdvanceRequest`, `InspectRequest`, `Voucher`, `DelegateCallVoucher`, `BytesLike`, …) are re-exported from `@cartesi/rollup`, which is a **peer dependency** — the native rollup device allows only one open handle per process, so the tree must hold a single copy. No runtime logic, no codegen; wallet and router depend on this rather than on `@deroll/app`.
 - **`packages/app/app`** (`@deroll/app`) — `createApp()`. The concrete `NativeApp` (in `src/app.ts`) wraps the native `Rollup` from `@cartesi/rollup`, drives the request loop via its blocking `finish()`, dispatches to advance/inspect handlers, and exposes `createNotice/createReport/createVoucher/...`. This is the entry point of every dApp.
 - **`packages/app/wallet`** (`@deroll/wallet`) — `createWallet()`. In-memory asset ledger (Ether, ERC-20, ERC-721, ERC-1155). Parses deposits coming from Cartesi portal contracts, tracks balances, supports internal transfers, and builds withdrawal vouchers. Largest/most complex package.
 - **`packages/app/router`** (`@deroll/router`) — `createRouter()`. URL-pattern dispatch (via `path-to-regexp`) for **inspect** requests; matched handlers return a string that becomes a report.
@@ -47,7 +47,9 @@ app.addInspectHandler(router.handler);   // router answers inspect queries
 app.start();
 ```
 
-Advance handlers run in registration order. With `broadcastAdvanceRequests` unset/false, the first handler to return `"accept"` short-circuits the rest; when true, all handlers run and the request is accepted if any accepted. Handler exceptions are caught and logged, never thrown out of the loop.
+Advance handlers run in registration order. With `broadcastAdvanceRequests` unset/false, the first handler to return `"accept"` short-circuits the rest; when true, all handlers run and the request is accepted if any accepted.
+
+A handler exception never escapes the loop, but it does end the request: `NativeApp` emits the error as a report and rejects immediately, skipping the remaining handlers (reports survive a rejection, notices and vouchers do not). Handlers may be sync or async; the output methods (`createNotice`, `createReport`, `createVoucher`, `createDelegateCallVoucher`, `registerException`) are **synchronous**, mirroring the binding — `finish` pauses the whole guest, so there is no I/O for the event loop to interleave with.
 
 ## Commands
 
@@ -77,8 +79,8 @@ Tests use **Vitest** and live in `__tests__/` (only `wallet` and `router` curren
 
 ## Build specifics
 
-- Each package builds with **tsup** to dual CJS + ESM (`dist/index.cjs` + `dist/index.js`) with `.d.ts`/`.d.cts` type declarations. Packages are `type: module`, `sideEffects: false`. `@deroll/core`'s build is a plain `tsup` — its types are hand-authored in `src/`, **not** generated (the previous OpenAPI/`openapi-typescript` codegen against `cartesi/openapi-interfaces` has been removed along with the HTTP transport).
-- `viem` is the shared toolkit for hex/ABI encoding throughout. Deposit parsing in `@deroll/wallet` relies on `@cartesi/codec` (`decodeDeposit`), the protocol's encode/decode library.
+- Each package builds with **tsup** to dual CJS + ESM (`dist/index.cjs` + `dist/index.js`) with `.d.ts`/`.d.cts` type declarations. Packages are `type: module`, `sideEffects: false`. `@deroll/core`'s build is a plain `tsup` — its types are hand-authored in `src/` (or re-exported from `@cartesi/rollup`), **not** generated (the previous OpenAPI/`openapi-typescript` codegen against `cartesi/openapi-interfaces` has been removed along with the HTTP transport).
+- `viem` is the shared toolkit for hex/ABI encoding throughout — except in `@deroll/core`, which is dependency-free apart from the `@cartesi/rollup` peer. Deposit parsing in `@deroll/wallet` relies on `@cartesi/codec` (`decodeDeposit`), the protocol's encode/decode library.
 
 ## Conventions
 

--- a/apps/docs/pages/app/add-advance-handler.mdx
+++ b/apps/docs/pages/app/add-advance-handler.mdx
@@ -12,8 +12,8 @@ import { createApp } from "@deroll/app";
 // create application
 const app = createApp();
 
-app.addAdvanceHandler(async ({ metadata, payload }) => { // [!code focus]
-    console.log(metadata, payload); // [!code focus]
+app.addAdvanceHandler((request) => { // [!code focus]
+    console.log(request); // [!code focus]
     return "accept"; // [!code focus]
 }); // [!code focus]
 ```
@@ -26,4 +26,4 @@ app.addAdvanceHandler(async ({ metadata, payload }) => { // [!code focus]
 
 Type: `AdvanceRequestHandler`
 
-An async function that receives an object with the request `metadata` and `payload`, and returns either `accept` or `reject`.
+A function that receives the advance request — its input metadata (`chainId`, `appContract`, `msgSender`, `blockNumber`, `blockTimestamp`, `prevRandao`, `index`) and its `payload` — and returns either `accept` or `reject`. It may be `async`, but it does not have to be.

--- a/apps/docs/pages/app/add-advance-handler.mdx
+++ b/apps/docs/pages/app/add-advance-handler.mdx
@@ -14,7 +14,7 @@ const app = createApp();
 
 app.addAdvanceHandler((request) => { // [!code focus]
     console.log(request); // [!code focus]
-    return "accept"; // [!code focus]
+    return true; // [!code focus]
 }); // [!code focus]
 ```
 
@@ -26,4 +26,4 @@ app.addAdvanceHandler((request) => { // [!code focus]
 
 Type: `AdvanceRequestHandler`
 
-A function that receives the advance request — its input metadata (`chainId`, `appContract`, `msgSender`, `blockNumber`, `blockTimestamp`, `prevRandao`, `index`) and its `payload` — and returns either `accept` or `reject`. It may be `async`, but it does not have to be.
+A function that receives the advance request — its input metadata (`chainId`, `appContract`, `msgSender`, `blockNumber`, `blockTimestamp`, `prevRandao`, `index`) and its `payload` — and returns `true` if it handled the input, or `false` to decline it and let the next handler try. It may be `async`, but it does not have to be.

--- a/apps/docs/pages/app/add-inspect-handler.mdx
+++ b/apps/docs/pages/app/add-inspect-handler.mdx
@@ -12,7 +12,7 @@ import { createApp } from "@deroll/app";
 // create application
 const app = createApp();
 
-app.addInspectHandler(async ({ payload }) => { // [!code focus]
+app.addInspectHandler(({ payload }) => { // [!code focus]
     console.log(payload); // [!code focus]
 }); // [!code focus]
 ```
@@ -25,4 +25,4 @@ app.addInspectHandler(async ({ payload }) => { // [!code focus]
 
 Type: `InspectRequestHandler`
 
-An async function that receives an object with the request `payload`.
+A function that receives the inspect request, which carries only a `payload`. It may be `async`, but it does not have to be.

--- a/apps/docs/pages/app/advance-handlers.mdx
+++ b/apps/docs/pages/app/advance-handlers.mdx
@@ -2,15 +2,16 @@
 
 ## Overview
 
-Advance handlers are async function callbacks that receive the `metadata` and `payload` of an input, and must return either `"accept"` or `"reject"`.
-The following example defines a request handler that accepts all requests, but just logs the input metadata.
+Advance handlers are function callbacks that receive an input — its metadata and its `payload` — and must return either `"accept"` or `"reject"`.
+They may be `async`, but they do not have to be: the underlying rollup device is synchronous, since waiting on it pauses the whole machine.
+The following example defines a request handler that accepts all requests, but just logs the input.
 
 ```ts twoslash
 import { createApp } from "@deroll/app";
 import { AdvanceRequestHandler } from "@deroll/core";
 
-const handler: AdvanceRequestHandler = async ({ metadata, payload }) => {
-    console.log(metadata);
+const handler: AdvanceRequestHandler = ({ msgSender, payload }) => {
+    console.log(msgSender, payload);
 // @noErrors
     return "
 //          ^|
@@ -34,18 +35,18 @@ import { createApp } from "@deroll/app";
 const app = createApp();
 
 // ---cut---
-app.addAdvanceHandler(async (data) => {
+app.addAdvanceHandler((data) => {
     console.log(data);
     return "accept";
 });
 
-app.addAdvanceHandler(async (data) => {
+app.addAdvanceHandler((data) => {
     // this code is never executed, because the first handler always returns "accept" // [!code hl]
     return "accept";
 });
 ```
 
-If a handler returns `"reject"` or **raises an exception**, the next handler in the list is executed.
+If a handler returns `"reject"`, the next handler in the list is executed.
 
 ```ts twoslash
 import { createApp } from "@deroll/app";
@@ -54,18 +55,29 @@ import { createApp } from "@deroll/app";
 const app = createApp();
 
 // ---cut---
-app.addAdvanceHandler(async (data) => {
+app.addAdvanceHandler((data) => {
     console.log(data);
     return "reject";
 });
 
-app.addAdvanceHandler(async (data) => {
+app.addAdvanceHandler((data) => {
     // this code will execute // [!code hl]
     return "accept";
 });
 ```
 
 If no handler returns `"accept"` the input is rejected and the machine is reverted to the initial state by the Cartesi node.
+
+## Exceptions
+
+If a handler **raises an exception**, the input could not be processed, so the whole request is rejected right there: the remaining handlers are *not* executed.
+This keeps a later handler from writing state on top of a partially applied one.
+
+The exception is also emitted as a [report](./create-report), which is what makes the failure observable from outside the machine — a rejection reverts the machine state and discards notices and vouchers, but reports survive it.
+
+:::warning
+In earlier `2.0.0` alpha releases an exception was only logged to `stderr`, and the next handler ran anyway. If your application relied on throwing to fall through to another handler, return `"reject"` instead.
+:::
 
 ## Broadcast Mode
 
@@ -80,12 +92,12 @@ const app = createApp({
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 });
 
-app.addAdvanceHandler(async (data) => {
+app.addAdvanceHandler((data) => {
     console.log(data);
     return "accept";
 });
 
-app.addAdvanceHandler(async (data) => {
+app.addAdvanceHandler((data) => {
     // this code executes, even when the first handler returns "accept" // [!code hl]
     return "accept";
 });

--- a/apps/docs/pages/app/advance-handlers.mdx
+++ b/apps/docs/pages/app/advance-handlers.mdx
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Advance handlers are function callbacks that receive an input — its metadata and its `payload` — and must return either `"accept"` or `"reject"`.
+Advance handlers are function callbacks that receive an input — its metadata and its `payload` — and must return a boolean saying whether they handled it: `true` accepts the input, `false` declines it and passes it to the next handler.
 They may be `async`, but they do not have to be: the underlying rollup device is synchronous, since waiting on it pauses the whole machine.
 The following example defines a request handler that accepts all requests, but just logs the input.
 
@@ -12,21 +12,23 @@ import { AdvanceRequestHandler } from "@deroll/core";
 
 const handler: AdvanceRequestHandler = ({ msgSender, payload }) => {
     console.log(msgSender, payload);
-// @noErrors
-    return "
-//          ^|
-}
+    return true; // accept
+};
 
 // create application
 const app = createApp();
 app.addAdvanceHandler(handler);
 ```
 
+Returning `false` does not by itself reject the input — it only declines it, so the next handler gets a chance.
+The input is rejected only when no handler accepted it.
+There is deliberately no `void` in the return type: a handler that falls off its end is a type error rather than a silent accept.
+
 ## Handlers Execution
 
 The application created with `createApp` holds a list of advance handlers that are executed in the order they were added.
 
-By default, when a handler returns `"accept"` the execution chain stops.
+By default, when a handler returns `true` the execution chain stops.
 
 ```ts twoslash
 import { createApp } from "@deroll/app";
@@ -37,16 +39,16 @@ const app = createApp();
 // ---cut---
 app.addAdvanceHandler((data) => {
     console.log(data);
-    return "accept";
+    return true;
 });
 
 app.addAdvanceHandler((data) => {
-    // this code is never executed, because the first handler always returns "accept" // [!code hl]
-    return "accept";
+    // this code is never executed, because the first handler always returns true // [!code hl]
+    return true;
 });
 ```
 
-If a handler returns `"reject"`, the next handler in the list is executed.
+If a handler returns `false`, the next handler in the list is executed.
 
 ```ts twoslash
 import { createApp } from "@deroll/app";
@@ -57,16 +59,16 @@ const app = createApp();
 // ---cut---
 app.addAdvanceHandler((data) => {
     console.log(data);
-    return "reject";
+    return false;
 });
 
 app.addAdvanceHandler((data) => {
     // this code will execute // [!code hl]
-    return "accept";
+    return true;
 });
 ```
 
-If no handler returns `"accept"` the input is rejected and the machine is reverted to the initial state by the Cartesi node.
+If no handler returns `true` the input is rejected and the machine is reverted to the initial state by the Cartesi node.
 
 ## Exceptions
 
@@ -76,7 +78,7 @@ This keeps a later handler from writing state on top of a partially applied one.
 The exception is also emitted as a [report](./create-report), which is what makes the failure observable from outside the machine — a rejection reverts the machine state and discards notices and vouchers, but reports survive it.
 
 :::warning
-In earlier `2.0.0` alpha releases an exception was only logged to `stderr`, and the next handler ran anyway. If your application relied on throwing to fall through to another handler, return `"reject"` instead.
+In earlier `2.0.0` alpha releases an exception was only logged to `stderr`, and the next handler ran anyway. If your application relied on throwing to fall through to another handler, return `false` instead.
 :::
 
 ## Broadcast Mode
@@ -94,11 +96,11 @@ const app = createApp({
 
 app.addAdvanceHandler((data) => {
     console.log(data);
-    return "accept";
+    return true;
 });
 
 app.addAdvanceHandler((data) => {
-    // this code executes, even when the first handler returns "accept" // [!code hl]
-    return "accept";
+    // this code executes, even when the first handler returns true // [!code hl]
+    return true;
 });
 ```

--- a/apps/docs/pages/app/create-delegate-call-voucher.mdx
+++ b/apps/docs/pages/app/create-delegate-call-voucher.mdx
@@ -20,13 +20,13 @@ import { encodeFunctionData, erc20Abi, parseAbi, parseUnits } from "viem";
 const app = createApp();
 
 // log incoming advance request
-app.addAdvanceHandler(async (data) => {
+app.addAdvanceHandler((data) => {
     const executor = "0xcA11bde05977b3631167028862bE2a173976CA11"; // batch-executor address // [!code focus]
     const token = "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"; // CTSI address
     const alice = "0x8f7599fa6fDDF2845a3beBcDCb055C7Ba1793a1f";
     const bob = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
 
-    const id = await app.createDelegateCallVoucher({ // [!code focus]
+    const id = app.createDelegateCallVoucher({ // [!code focus]
         destination: executor, // [!code focus]
         payload: encodeFunctionData({ // [!code focus]
             abi: parseAbi([ // [!code focus]

--- a/apps/docs/pages/app/create-delegate-call-voucher.mdx
+++ b/apps/docs/pages/app/create-delegate-call-voucher.mdx
@@ -50,7 +50,7 @@ app.addAdvanceHandler((data) => {
             ], // [!code focus]
         }), // [!code focus]
     }); // [!code focus]
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/create-notice.mdx
+++ b/apps/docs/pages/app/create-notice.mdx
@@ -14,8 +14,8 @@ import { stringToHex } from "viem";
 const app = createApp();
 
 // log incoming advance request
-app.addAdvanceHandler(async (data) => {
-    const id = await app.createNotice({ payload: stringToHex("hello") }); // [!code focus]
+app.addAdvanceHandler((data) => {
+    const id = app.createNotice(stringToHex("hello")); // [!code focus]
     return "accept";
 });
 ```
@@ -30,6 +30,8 @@ The id of the notice output.
 
 ### payload
 
-Type: `Hex`
+Type: `BytesLike`
 
-Binary payload of the notice, hex-encoded.
+Binary payload of the notice, as a `0x`-prefixed hex string or a `Uint8Array`/`Buffer`.
+
+`createNotice` takes the payload directly; it is not wrapped in an object.

--- a/apps/docs/pages/app/create-notice.mdx
+++ b/apps/docs/pages/app/create-notice.mdx
@@ -16,7 +16,7 @@ const app = createApp();
 // log incoming advance request
 app.addAdvanceHandler((data) => {
     const id = app.createNotice(stringToHex("hello")); // [!code focus]
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/create-report.mdx
+++ b/apps/docs/pages/app/create-report.mdx
@@ -18,7 +18,7 @@ const app = createApp();
 // log incoming advance request
 app.addAdvanceHandler((data) => {
     app.createReport(stringToHex("hello")); // [!code focus]
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/create-report.mdx
+++ b/apps/docs/pages/app/create-report.mdx
@@ -16,8 +16,8 @@ import { stringToHex } from "viem";
 const app = createApp();
 
 // log incoming advance request
-app.addAdvanceHandler(async (data) => {
-    await app.createReport({ payload: stringToHex("hello") }); // [!code focus]
+app.addAdvanceHandler((data) => {
+    app.createReport(stringToHex("hello")); // [!code focus]
     return "accept";
 });
 ```
@@ -32,6 +32,8 @@ Unlike notices and vouchers, reports are not indexed, so `createReport` does not
 
 ### payload
 
-Type: `Hex`
+Type: `BytesLike`
 
-Binary payload of the report, hex-encoded.
+Binary payload of the report, as a `0x`-prefixed hex string or a `Uint8Array`/`Buffer`.
+
+`createReport` takes the payload directly; it is not wrapped in an object.

--- a/apps/docs/pages/app/create-voucher.mdx
+++ b/apps/docs/pages/app/create-voucher.mdx
@@ -14,12 +14,12 @@ import { encodeFunctionData, erc20Abi, parseUnits } from "viem";
 const app = createApp();
 
 // log incoming advance request
-app.addAdvanceHandler(async (data) => {
+app.addAdvanceHandler((data) => {
     const token = "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"; // CTSI address // [!code focus]
     const to = "0x8f7599fa6fDDF2845a3beBcDCb055C7Ba1793a1f"; // CTSI recipient // [!code focus]
     const amount = parseUnits("1", 18); // [!code focus]
 
-    const id = await app.createVoucher({ // [!code focus]
+    const id = app.createVoucher({ // [!code focus]
         destination: token, // [!code focus]
         payload: encodeFunctionData({ // [!code focus]
             abi: erc20Abi, // [!code focus]

--- a/apps/docs/pages/app/create-voucher.mdx
+++ b/apps/docs/pages/app/create-voucher.mdx
@@ -27,7 +27,7 @@ app.addAdvanceHandler((data) => {
             args: [to, amount], // [!code focus]
         }), // [!code focus]
     }); // [!code focus]
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/data-encoding.mdx
+++ b/apps/docs/pages/app/data-encoding.mdx
@@ -86,11 +86,11 @@ app.addAdvanceHandler(({ payload }) => {
             const [dragonId, weapon] = args;
 //                                     ^?
             console.log(`attacking dragon ${dragonId} with ${weapon}...`);
-            return "accept";
+            return true;
 
         case "drinkPotion":
             console.log(`drinking potion...`);
-            return "accept";
+            return true;
     }
 });
 

--- a/apps/docs/pages/app/data-encoding.mdx
+++ b/apps/docs/pages/app/data-encoding.mdx
@@ -75,7 +75,7 @@ const abi = parseAbi([
 ]);
 
 // handle input encoded as ABI function call
-app.addAdvanceHandler(async ({ payload }) => {
+app.addAdvanceHandler(({ payload }) => {
     const { functionName, args } = decodeFunctionData({ abi, data: toHex(payload) });
 
     switch (functionName) {

--- a/apps/docs/pages/app/inspect-handlers.mdx
+++ b/apps/docs/pages/app/inspect-handlers.mdx
@@ -2,7 +2,8 @@
 
 ## Overview
 
-Inspect handlers are async function callbacks that receive the `payload` of an inspect request, and has no return value.
+Inspect handlers are function callbacks that receive the `payload` of an inspect request, and have no return value.
+They may be `async`, but they do not have to be.
 The following example defines an inspect handler that logs the payload, decode it as a string and add a report with the string uppercase value.
 
 ```ts twoslash
@@ -13,10 +14,10 @@ import { stringToHex, hexToString } from "viem";
 // create application
 const app = createApp();
 
-const handler: InspectRequestHandler = async ({ payload }) => {
+const handler: InspectRequestHandler = ({ payload }) => {
     console.log(payload);
     const str = payload.toString();
-    await app.createReport({ payload: stringToHex(str.toUpperCase()) });
+    app.createReport(stringToHex(str.toUpperCase()));
 }
 
 app.addInspectHandler(handler);

--- a/apps/docs/pages/app/migrating.mdx
+++ b/apps/docs/pages/app/migrating.mdx
@@ -26,22 +26,29 @@ The `ROLLUP_HTTP_SERVER_URL` environment variable is no longer used. The only re
 
 ### Input metadata
 
-The input metadata received in an advance handler has changed.
+The input metadata received in an advance handler has changed, and it is no longer nested under a `metadata` property — the request is a single flat object.
 
 ```diff
--chain_id: number;
--msg_sender: Address;
--epochIndex: bigint;
--input_index: number;
--block_number: number;
--timestamp: number;
-+chainId: bigint;
-+appContract: Address;
-+msgSender: Address;
-+index: bigint;
-+blockNumber: bigint;
-+blockTimestamp: bigint;
-+prevRandao: bigint;
+-{ metadata: { chain_id: number; msg_sender: Address; epochIndex: bigint;
+-              input_index: number; block_number: number; timestamp: number },
+-  payload: Hex }
++{ type: "advance"; chainId: bigint; appContract: Address; msgSender: Address;
++  index: bigint; blockNumber: bigint; blockTimestamp: bigint;
++  prevRandao: bigint; payload: Buffer }
+```
+
+```ts
+// v1
+app.addAdvanceHandler(async ({ metadata, payload }) => {
+    console.log(metadata.msg_sender);
+    return "accept";
+});
+
+// v2
+app.addAdvanceHandler(({ msgSender }) => {
+    console.log(msgSender);
+    return "accept";
+});
 ```
 
 ### Payload type
@@ -61,12 +68,12 @@ import { encodeFunctionData, erc20Abi, parseUnits } from "viem";
 const app = createApp();
 
 // log incoming advance request
-app.addAdvanceHandler(async (data) => {
+app.addAdvanceHandler((data) => {
     const token = "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"; // CTSI address
     const to = "0x8f7599fa6fDDF2845a3beBcDCb055C7Ba1793a1f"; // CTSI recipient
     const amount = parseUnits("1", 18);
 
-    const id = await app.createVoucher({
+    const id = app.createVoucher({
         destination: token,
         payload: encodeFunctionData({
             abi: erc20Abi,
@@ -104,6 +111,46 @@ function validateOutput(bytes output, OutputValidityProof proof);
 ```
 
 This mainly affects the frontend or relayer code that executes vouchers, not the advance and inspect handlers you write with deroll.
+
+### Outputs are synchronous
+
+Emitting an output is a write to the rollup device, not I/O the event loop can interleave with, so the output methods are synchronous and no longer return promises.
+The notice and report payloads are also passed directly, rather than wrapped in an object.
+
+```diff
+-const id = await app.createNotice({ payload: stringToHex("hello") });
+-await app.createReport({ payload: stringToHex("hello") });
+-const id = await app.createVoucher({ destination, payload });
++const id = app.createNotice(stringToHex("hello"));
++app.createReport(stringToHex("hello"));
++const id = app.createVoucher({ destination, payload });
+```
+
+Vouchers keep their object argument, since they carry a `destination` and an optional `value` besides the payload.
+
+Handlers may still be `async` — they are awaited — but they no longer have to be.
+
+### registerException
+
+`registerException` is now part of the `App` interface, so it is reachable from the value returned by `createApp`.
+It signals that a request could not be processed at all, which halts the machine.
+
+### Handler exceptions
+
+An exception raised by an advance handler now rejects the input immediately instead of falling through to the next handler, and the error is emitted as a report.
+See [Advance Handlers](/app/advance-handlers#exceptions).
+
+### Protocol types come from @cartesi/rollup
+
+`@deroll/core` no longer declares its own copies of the rollup protocol types.
+It re-exports them from [`@cartesi/rollup`](https://github.com/cartesi/rollups-ts), the libcmt binding, so the two can never drift:
+
+- `AdvanceRequest`, `InspectRequest` and `RollupRequest` replace `AdvanceRequestData`, `InspectRequestData`, `AdvanceRequestMetadata` and the `RollupAdvanceRequest`/`RollupInspectRequest` pair.
+- `BytesLike` replaces `Payload`, and it is what the output methods accept.
+- `Voucher` and `DelegateCallVoucher` now come from the binding, so `destination` accepts a `Uint8Array` as well as a hex address, and a voucher `value` accepts a `number` or hex as well as a `bigint`.
+- The `Notice`, `Report` and `Exception` wrapper types are gone, along with the `NoticeResponse`/`ReportResponse`/`VoucherResponse` types left over from the HTTP transport.
+
+`@cartesi/rollup` is a peer dependency of `@deroll/core`, which keeps a single copy of the native binding in the dependency tree — the rollup device allows only one open handle per process.
 
 ### GraphQL service deprecated
 

--- a/apps/docs/pages/app/migrating.mdx
+++ b/apps/docs/pages/app/migrating.mdx
@@ -41,13 +41,13 @@ The input metadata received in an advance handler has changed, and it is no long
 // v1
 app.addAdvanceHandler(async ({ metadata, payload }) => {
     console.log(metadata.msg_sender);
-    return "accept";
+    return true;
 });
 
 // v2
 app.addAdvanceHandler(({ msgSender }) => {
     console.log(msgSender);
-    return "accept";
+    return true;
 });
 ```
 
@@ -82,7 +82,7 @@ app.addAdvanceHandler((data) => {
         }),
         value: 1000000000000000000n, // [!code focus]
     });
-    return "accept";
+    return true;
 });
 ```
 
@@ -111,6 +111,24 @@ function validateOutput(bytes output, OutputValidityProof proof);
 ```
 
 This mainly affects the frontend or relayer code that executes vouchers, not the advance and inspect handlers you write with deroll.
+
+### Handlers return a boolean
+
+An advance handler used to return `"accept"` or `"reject"`.
+Those were the `status` field of the Rollup HTTP Server's `/finish` request body, which deroll passed through verbatim; with the HTTP transport gone, handlers return a boolean instead, matching `finish({ accept })` in the binding.
+
+```diff
+-app.addAdvanceHandler(async (data) => {
+-    if (!isMine(data)) return "reject";
+-    return "accept";
++app.addAdvanceHandler((request) => {
++    if (!isMine(request)) return false;
++    return true;
+ });
+```
+
+`true` accepts the input; `false` declines it and passes it to the next handler, exactly as `"reject"` used to.
+The return type is a strict `boolean` with no `void` — `Rollup.run` in the binding accepts a request unless a handler returns `false`, while deroll rejects unless a handler opts in, so a handler that falls off its end has to be a type error rather than a silent accept.
 
 ### Outputs are synchronous
 

--- a/apps/docs/pages/app/overview.mdx
+++ b/apps/docs/pages/app/overview.mdx
@@ -15,13 +15,13 @@ import { createApp } from "@deroll/app";
 const app = createApp();
 
 // handle advance requests (inputs)
-app.addAdvanceHandler(async ({ metadata, payload }) => {
-    console.log({ metadata, payload });
+app.addAdvanceHandler((request) => {
+    console.log(request);
     return "accept";
 });
 
 // handle inspect requests (read-only queries)
-app.addInspectHandler(async ({ payload }) => {
+app.addInspectHandler(({ payload }) => {
     console.log(payload);
 });
 

--- a/apps/docs/pages/app/overview.mdx
+++ b/apps/docs/pages/app/overview.mdx
@@ -17,7 +17,7 @@ const app = createApp();
 // handle advance requests (inputs)
 app.addAdvanceHandler((request) => {
     console.log(request);
-    return "accept";
+    return true;
 });
 
 // handle inspect requests (read-only queries)
@@ -31,7 +31,7 @@ app.start().catch(() => process.exit(1));
 
 ## Registering handlers
 
-- [addAdvanceHandler](./add-advance-handler) — process state-changing inputs; handlers return `"accept"` or `"reject"`.
+- [addAdvanceHandler](./add-advance-handler) — process state-changing inputs; handlers return `true` to accept an input or `false` to decline it.
 - [addInspectHandler](./add-inspect-handler) — answer read-only queries; handlers can only produce reports.
 
 ## Producing outputs

--- a/apps/docs/pages/app/quick-start.mdx
+++ b/apps/docs/pages/app/quick-start.mdx
@@ -50,13 +50,13 @@ import { createApp } from "@deroll/app";
 const app = createApp();
 
 // log incoming advance request
-app.addAdvanceHandler(async ({ metadata, payload }) => {
-    console.log({ metadata, payload });
+app.addAdvanceHandler((request) => {
+    console.log(request);
     return "accept";
 });
 
 // log incoming inspect request
-app.addInspectHandler(async ({ payload }) => {
+app.addInspectHandler(({ payload }) => {
     console.log(payload);
 });
 
@@ -133,28 +133,27 @@ cartesi send
 
 ```bash [log]
 {
-  metadata: {
-    chainId: 31337n,
-    appContract: '0xa418ed392a99a1a0c08f96345e9a9b7514047ee2',
-    msgSender: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
-    blockNumber: 158n,
-    blockTimestamp: 1782243979n,
-    prevRandao: 50953495096857333910293917481377617449822294969307609189375131362321353489028n,
-    index: 0n
-  },
+  type: 'advance',
+  chainId: 31337n,
+  appContract: '0xa418ed392a99a1a0c08f96345e9a9b7514047ee2',
+  msgSender: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+  blockNumber: 158n,
+  blockTimestamp: 1782243979n,
+  prevRandao: 50953495096857333910293917481377617449822294969307609189375131362321353489028n,
+  index: 0n,
   payload: <Buffer 68 65 6c 6c 6f>
 }
 ```
 ```ts [src/index.ts]
 // log incoming advance request
-app.addAdvanceHandler(async ({ metadata, payload }) => {
-    console.log({ metadata, payload }); // [!code focus]
+app.addAdvanceHandler((request) => {
+    console.log(request); // [!code focus]
     return "accept";
 });
 ```
 :::
 
-If you check in the `cartesi rollups logs` log you will see the output above, which is the result of the `console.log(data)` of the application code.
+If you check in the `cartesi rollups logs` log you will see the output above, which is the result of the `console.log(request)` of the application code.
 Notice that the `payload` is the hex encoding of the `hello` string. More on that on the [Data Encoding](/app/data-encoding) section.
 
 ### Send input using `cast`
@@ -212,7 +211,7 @@ $ curl -X POST -d "hello" http://127.0.0.1:6751/inspect/<application>
 ```
 ```ts [src/index.ts]
 // log incoming inspect request
-app.addInspectHandler(async (data) => {
+app.addInspectHandler((data) => {
     console.log(data); // [!code focus]
 });
 ```

--- a/apps/docs/pages/app/quick-start.mdx
+++ b/apps/docs/pages/app/quick-start.mdx
@@ -52,7 +52,7 @@ const app = createApp();
 // log incoming advance request
 app.addAdvanceHandler((request) => {
     console.log(request);
-    return "accept";
+    return true;
 });
 
 // log incoming inspect request
@@ -148,7 +148,7 @@ cartesi send
 // log incoming advance request
 app.addAdvanceHandler((request) => {
     console.log(request); // [!code focus]
-    return "accept";
+    return true;
 });
 ```
 :::

--- a/apps/docs/pages/app/wallet.mdx
+++ b/apps/docs/pages/app/wallet.mdx
@@ -65,13 +65,13 @@ const wallet = createWallet();
 
 app.addAdvanceHandler(wallet.handler);
 
-app.addInspectHandler(async (data) => { // [!code ++]
+app.addInspectHandler((data) => { // [!code ++]
     const address = toHex(data.payload); // [!code ++]
     const balance = wallet.erc20BalanceOf( // [!code ++]
         "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D", // [!code ++]
         address, // [!code ++]
     ); // [!code ++]
-    await app.createReport({ payload: numberToHex(balance) }); // [!code ++]
+    app.createReport(numberToHex(balance)); // [!code ++]
 }); // [!code ++]
 
 // start app
@@ -103,24 +103,24 @@ const app = createApp();
 const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
-app.addAdvanceHandler(async (data) => { // [!code ++]
+app.addAdvanceHandler((data) => { // [!code ++]
     const amount = hexToBigInt(toHex(data.payload)); // [!code ++]
     const voucher = wallet.withdrawERC20( // [!code ++]
         "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D", // [!code ++]
-        data.metadata.msgSender, // [!code ++]
+        data.msgSender, // [!code ++]
         amount, // [!code ++]
     ); // [!code ++]
-    await app.createVoucher(voucher); // [!code ++]
+    app.createVoucher(voucher); // [!code ++]
     return "accept"; // [!code ++]
 }); // [!code ++]
 
-app.addInspectHandler(async (data) => {
+app.addInspectHandler((data) => {
     const address = toHex(data.payload);
     const balance = wallet.erc20BalanceOf(
         "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D",
         address,
     );
-    await app.createReport({ payload: numberToHex(balance) });
+    app.createReport(numberToHex(balance));
 });
 
 // start app
@@ -143,9 +143,9 @@ import { createERC20TransferVoucher } from "@deroll/wallet";
 // create app
 const app = createApp();
 
-app.addAdvanceHandler(async (data) => { // [!code focus]
+app.addAdvanceHandler((data) => { // [!code focus]
     const deposit = decodeDeposit({ // [!code focus]
-        msgSender: data.metadata.msgSender, // [!code focus]
+        msgSender: data.msgSender, // [!code focus]
         payload: data.payload, // [!code focus]
     }); // [!code focus]
     if (deposit?.type === "Erc20Deposit") { // [!code focus]
@@ -154,7 +154,7 @@ app.addAdvanceHandler(async (data) => { // [!code focus]
             deposit.sender, // [!code focus]
             deposit.value, // [!code focus]
         ); // [!code focus]
-        await app.createVoucher(voucher); // [!code focus]
+        app.createVoucher(voucher); // [!code focus]
     } // [!code focus]
     return "accept"; // [!code focus]
 }); // [!code focus]

--- a/apps/docs/pages/app/wallet.mdx
+++ b/apps/docs/pages/app/wallet.mdx
@@ -111,7 +111,7 @@ app.addAdvanceHandler((data) => { // [!code ++]
         amount, // [!code ++]
     ); // [!code ++]
     app.createVoucher(voucher); // [!code ++]
-    return "accept"; // [!code ++]
+    return true; // [!code ++]
 }); // [!code ++]
 
 app.addInspectHandler((data) => {
@@ -156,7 +156,7 @@ app.addAdvanceHandler((data) => { // [!code focus]
         ); // [!code focus]
         app.createVoucher(voucher); // [!code focus]
     } // [!code focus]
-    return "accept"; // [!code focus]
+    return true; // [!code focus]
 }); // [!code focus]
 
 // start app

--- a/apps/docs/pages/app/wallet/create-erc1155-batch-transfer-voucher.mdx
+++ b/apps/docs/pages/app/wallet/create-erc1155-batch-transfer-voucher.mdx
@@ -28,7 +28,7 @@ app.addAdvanceHandler(({ msgSender }) => {
         "0x", // [!code focus]
     ); // [!code focus]
     app.createVoucher(voucher);
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/create-erc1155-batch-transfer-voucher.mdx
+++ b/apps/docs/pages/app/wallet/create-erc1155-batch-transfer-voucher.mdx
@@ -16,18 +16,18 @@ const app = createApp();
 
 const application = "0xab7528bb862fb57e8a2bcd567a2e929a0be56a5e";
 const token = "0x04d724738873CB6a86328D2EbAEb2079D715e61e"; // ERC-1155 address
-app.addAdvanceHandler(async ({ metadata }) => {
+app.addAdvanceHandler(({ msgSender }) => {
     const value1 = parseUnits("1", 18);
     const value2 = parseUnits("1", 18);
     const voucher = createERC1155BatchTransferVoucher( // [!code focus]
         token, // [!code focus]
         application, // [!code focus]
-        metadata.msgSender, // [!code focus]
+        msgSender, // [!code focus]
         [1n, 2n], // [!code focus]
         [value1, value2], // [!code focus]
         "0x", // [!code focus]
     ); // [!code focus]
-    await app.createVoucher(voucher);
+    app.createVoucher(voucher);
     return "accept";
 });
 ```

--- a/apps/docs/pages/app/wallet/create-erc1155-single-transfer-voucher.mdx
+++ b/apps/docs/pages/app/wallet/create-erc1155-single-transfer-voucher.mdx
@@ -27,7 +27,7 @@ app.addAdvanceHandler(({ msgSender }) => {
         "0x", // [!code focus]
     ); // [!code focus]
     app.createVoucher(voucher);
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/create-erc1155-single-transfer-voucher.mdx
+++ b/apps/docs/pages/app/wallet/create-erc1155-single-transfer-voucher.mdx
@@ -16,17 +16,17 @@ const app = createApp();
 
 const application = "0xab7528bb862fb57e8a2bcd567a2e929a0be56a5e";
 const token = "0x04d724738873CB6a86328D2EbAEb2079D715e61e"; // ERC-1155 address
-app.addAdvanceHandler(async ({ metadata }) => {
+app.addAdvanceHandler(({ msgSender }) => {
     const value = parseUnits("1", 18);
     const voucher = createERC1155SingleTransferVoucher( // [!code focus]
         token, // [!code focus]
         application, // [!code focus]
-        metadata.msgSender, // [!code focus]
+        msgSender, // [!code focus]
         1n, // [!code focus]
         value, // [!code focus]
         "0x", // [!code focus]
     ); // [!code focus]
-    await app.createVoucher(voucher);
+    app.createVoucher(voucher);
     return "accept";
 });
 ```

--- a/apps/docs/pages/app/wallet/create-erc20-transfer-voucher.mdx
+++ b/apps/docs/pages/app/wallet/create-erc20-transfer-voucher.mdx
@@ -23,7 +23,7 @@ app.addAdvanceHandler(({ msgSender }) => {
         value, // [!code focus]
     ); // [!code focus]
     app.createVoucher(voucher);
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/create-erc20-transfer-voucher.mdx
+++ b/apps/docs/pages/app/wallet/create-erc20-transfer-voucher.mdx
@@ -15,14 +15,14 @@ import { parseUnits } from "viem";
 const app = createApp();
 
 const token = "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"; // CTSI address
-app.addAdvanceHandler(async ({ metadata }) => {
+app.addAdvanceHandler(({ msgSender }) => {
     const value = parseUnits("1", 18);
     const voucher = createERC20TransferVoucher( // [!code focus]
         token, // [!code focus]
-        metadata.msgSender, // [!code focus]
+        msgSender, // [!code focus]
         value, // [!code focus]
     ); // [!code focus]
-    await app.createVoucher(voucher);
+    app.createVoucher(voucher);
     return "accept";
 });
 ```

--- a/apps/docs/pages/app/wallet/create-erc721-transfer-voucher.mdx
+++ b/apps/docs/pages/app/wallet/create-erc721-transfer-voucher.mdx
@@ -23,7 +23,7 @@ app.addAdvanceHandler(({ msgSender }) => {
         1n, // [!code focus]
     ); // [!code focus]
     app.createVoucher(voucher);
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/create-erc721-transfer-voucher.mdx
+++ b/apps/docs/pages/app/wallet/create-erc721-transfer-voucher.mdx
@@ -15,14 +15,14 @@ const app = createApp();
 
 const application = "0xab7528bb862fb57e8a2bcd567a2e929a0be56a5e";
 const token = "0xc6582A9b48F211Fa8c2B5b16CB615eC39bcA653B"; // ERC-721 address
-app.addAdvanceHandler(async ({ metadata }) => {
+app.addAdvanceHandler(({ msgSender }) => {
     const voucher = createERC721TransferVoucher( // [!code focus]
         token, // [!code focus]
         application, // [!code focus]
-        metadata.msgSender, // [!code focus]
+        msgSender, // [!code focus]
         1n, // [!code focus]
     ); // [!code focus]
-    await app.createVoucher(voucher);
+    app.createVoucher(voucher);
     return "accept";
 });
 ```

--- a/apps/docs/pages/app/wallet/create-withdraw-ether-voucher.mdx
+++ b/apps/docs/pages/app/wallet/create-withdraw-ether-voucher.mdx
@@ -22,7 +22,7 @@ app.addAdvanceHandler(({ msgSender }) => {
         value, // [!code focus]
     ); // [!code focus]
     app.createVoucher(voucher);
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/create-withdraw-ether-voucher.mdx
+++ b/apps/docs/pages/app/wallet/create-withdraw-ether-voucher.mdx
@@ -15,13 +15,13 @@ import { parseEther } from "viem";
 const app = createApp();
 
 const application = "0xab7528bb862fb57e8a2bcd567a2e929a0be56a5e";
-app.addAdvanceHandler(async ({ metadata }) => {
+app.addAdvanceHandler(({ msgSender }) => {
     const value = parseEther("1");
     const voucher = createWithdrawEtherVoucher( // [!code focus]
-        metadata.msgSender, // [!code focus]
+        msgSender, // [!code focus]
         value, // [!code focus]
     ); // [!code focus]
-    await app.createVoucher(voucher);
+    app.createVoucher(voucher);
     return "accept";
 });
 ```

--- a/apps/docs/pages/app/wallet/erc1155-balance-of.mdx
+++ b/apps/docs/pages/app/wallet/erc1155-balance-of.mdx
@@ -19,7 +19,7 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0x04d724738873CB6a86328D2EbAEb2079D715e61e"; // ERC-1155 address // [!code focus]
-app.addInspectHandler(async ({ payload }) => { // [!code focus]
+app.addInspectHandler(({ payload }) => { // [!code focus]
     const address = payload.toString(); // [!code focus]
     const balance = wallet.erc1155BalanceOf(token, address, 1n); // [!code focus]
     console.log(balance); // [!code focus]

--- a/apps/docs/pages/app/wallet/erc20-balance-of.mdx
+++ b/apps/docs/pages/app/wallet/erc20-balance-of.mdx
@@ -19,7 +19,7 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"; // CTSI address // [!code focus]
-app.addInspectHandler(async ({ payload }) => { // [!code focus]
+app.addInspectHandler(({ payload }) => { // [!code focus]
     const address = payload.toString(); // [!code focus]
     const balance = wallet.erc20BalanceOf(token, address); // [!code focus]
     console.log(balance); // [!code focus]

--- a/apps/docs/pages/app/wallet/erc721-has.mdx
+++ b/apps/docs/pages/app/wallet/erc721-has.mdx
@@ -19,7 +19,7 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0xc6582A9b48F211Fa8c2B5b16CB615eC39bcA653B"; // NFT address // [!code focus]
-app.addInspectHandler(async ({ payload }) => { // [!code focus]
+app.addInspectHandler(({ payload }) => { // [!code focus]
     const address = payload.toString(); // [!code focus]
     const hasOne = wallet.erc721Has(token, address, 1n); // [!code focus]
     console.log(hasOne); // [!code focus]

--- a/apps/docs/pages/app/wallet/ether-balance-of.mdx
+++ b/apps/docs/pages/app/wallet/ether-balance-of.mdx
@@ -18,7 +18,7 @@ const wallet = createWallet();
 
 app.addAdvanceHandler(wallet.handler);
 
-app.addInspectHandler(async ({ payload }) => { // [!code focus]
+app.addInspectHandler(({ payload }) => { // [!code focus]
     const address = payload.toString(); // [!code focus]
     const balance = wallet.etherBalanceOf(address); // [!code focus]
     console.log(balance); // [!code focus]

--- a/apps/docs/pages/app/wallet/get-wallet.mdx
+++ b/apps/docs/pages/app/wallet/get-wallet.mdx
@@ -18,7 +18,7 @@ const wallet = createWallet();
 
 app.addAdvanceHandler(wallet.handler);
 
-app.addInspectHandler(async ({ payload }) => { // [!code focus]
+app.addInspectHandler(({ payload }) => { // [!code focus]
     const address = payload.toString(); // [!code focus]
     const userWallet = wallet.getWallet(address); // [!code focus]
     const balance = userWallet.ether; // [!code focus]

--- a/apps/docs/pages/app/wallet/transfer-batch-erc1155.mdx
+++ b/apps/docs/pages/app/wallet/transfer-batch-erc1155.mdx
@@ -21,13 +21,13 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0x04d724738873CB6a86328D2EbAEb2079D715e61e"; // ERC-1155 address
-app.addAdvanceHandler(async ({ metadata, payload }) => {
+app.addAdvanceHandler(({ msgSender, payload }) => {
     const value1 = parseUnits("1", 18);
     const value2 = parseUnits("1", 18);
     const address = payload.toString();
     wallet.transferBatchERC1155( // [!code focus]
         token, // [!code focus]
-        metadata.msgSender, // [!code focus]
+        msgSender, // [!code focus]
         address, // [!code focus]
         [1n, 2n], // [!code focus]
         [value1, value2], // [!code focus]

--- a/apps/docs/pages/app/wallet/transfer-batch-erc1155.mdx
+++ b/apps/docs/pages/app/wallet/transfer-batch-erc1155.mdx
@@ -32,7 +32,7 @@ app.addAdvanceHandler(({ msgSender, payload }) => {
         [1n, 2n], // [!code focus]
         [value1, value2], // [!code focus]
     ); // [!code focus]
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/transfer-erc1155.mdx
+++ b/apps/docs/pages/app/wallet/transfer-erc1155.mdx
@@ -21,10 +21,10 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0x04d724738873CB6a86328D2EbAEb2079D715e61e"; // ERC-1155 address
-app.addAdvanceHandler(async ({ metadata, payload }) => {
+app.addAdvanceHandler(({ msgSender, payload }) => {
     const address = payload.toString();
     const value = parseUnits("1", 18);
-    wallet.transferERC1155(token, metadata.msgSender, address, 1n, value); // [!code focus]
+    wallet.transferERC1155(token, msgSender, address, 1n, value); // [!code focus]
     return "accept";
 });
 ```

--- a/apps/docs/pages/app/wallet/transfer-erc1155.mdx
+++ b/apps/docs/pages/app/wallet/transfer-erc1155.mdx
@@ -25,7 +25,7 @@ app.addAdvanceHandler(({ msgSender, payload }) => {
     const address = payload.toString();
     const value = parseUnits("1", 18);
     wallet.transferERC1155(token, msgSender, address, 1n, value); // [!code focus]
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/transfer-erc20.mdx
+++ b/apps/docs/pages/app/wallet/transfer-erc20.mdx
@@ -21,10 +21,10 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"; // CTSI address
-app.addAdvanceHandler(async ({ metadata, payload }) => {
+app.addAdvanceHandler(({ msgSender, payload }) => {
     const value = parseUnits("1", 18);
     const address = payload.toString();
-    wallet.transferERC20(token, metadata.msgSender, address, value); // [!code focus]
+    wallet.transferERC20(token, msgSender, address, value); // [!code focus]
     return "accept";
 });
 ```

--- a/apps/docs/pages/app/wallet/transfer-erc20.mdx
+++ b/apps/docs/pages/app/wallet/transfer-erc20.mdx
@@ -25,7 +25,7 @@ app.addAdvanceHandler(({ msgSender, payload }) => {
     const value = parseUnits("1", 18);
     const address = payload.toString();
     wallet.transferERC20(token, msgSender, address, value); // [!code focus]
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/transfer-erc721.mdx
+++ b/apps/docs/pages/app/wallet/transfer-erc721.mdx
@@ -20,9 +20,9 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0xc6582A9b48F211Fa8c2B5b16CB615eC39bcA653B"; // NFT address
-app.addAdvanceHandler(async ({ metadata, payload }) => {
+app.addAdvanceHandler(({ msgSender, payload }) => {
     const address = payload.toString();
-    wallet.transferERC721(token, metadata.msgSender, address, 1n); // [!code focus]
+    wallet.transferERC721(token, msgSender, address, 1n); // [!code focus]
     return "accept";
 });
 ```

--- a/apps/docs/pages/app/wallet/transfer-erc721.mdx
+++ b/apps/docs/pages/app/wallet/transfer-erc721.mdx
@@ -23,7 +23,7 @@ const token = "0xc6582A9b48F211Fa8c2B5b16CB615eC39bcA653B"; // NFT address
 app.addAdvanceHandler(({ msgSender, payload }) => {
     const address = payload.toString();
     wallet.transferERC721(token, msgSender, address, 1n); // [!code focus]
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/transfer-ether.mdx
+++ b/apps/docs/pages/app/wallet/transfer-ether.mdx
@@ -24,7 +24,7 @@ app.addAdvanceHandler(({ msgSender, payload }) => {
     const value = parseEther("1");
     const address = payload.toString();
     wallet.transferEther(msgSender, address, value); // [!code focus]
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/transfer-ether.mdx
+++ b/apps/docs/pages/app/wallet/transfer-ether.mdx
@@ -5,7 +5,7 @@ Transfer L2 ETH (or base layer native token) from one user to another.
 ## Usage
 
 The following example is an advance handler that transfers 1 ETH from the sender of the input to a recipient specified in the input payload.
-If the sender does not have enough balance an exception is raised, and that handler is aborted.
+If the sender does not have enough balance an exception is raised, which rejects the input and emits the error as a report.
 
 ```ts twoslash
 import { createApp } from "@deroll/app";
@@ -20,10 +20,10 @@ const wallet = createWallet();
 
 app.addAdvanceHandler(wallet.handler);
 
-app.addAdvanceHandler(async ({ metadata, payload }) => {
+app.addAdvanceHandler(({ msgSender, payload }) => {
     const value = parseEther("1");
     const address = payload.toString();
-    wallet.transferEther(metadata.msgSender, address, value); // [!code focus]
+    wallet.transferEther(msgSender, address, value); // [!code focus]
     return "accept";
 });
 ```

--- a/apps/docs/pages/app/wallet/withdraw-batch-erc1155.mdx
+++ b/apps/docs/pages/app/wallet/withdraw-batch-erc1155.mdx
@@ -20,9 +20,9 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0x04d724738873CB6a86328D2EbAEb2079D715e61e"; // ERC-1155 address
-app.addAdvanceHandler(async ({ metadata }) => {
-    const user = metadata.msgSender;
-    const dapp = metadata.appContract;
+app.addAdvanceHandler(({ msgSender, appContract }) => {
+    const user = msgSender;
+    const dapp = appContract;
     const value1 = wallet.erc1155BalanceOf(token, user, 1n);
     const value2 = wallet.erc1155BalanceOf(token, user, 2n);
     if (value1 > 0 && value2 > 0) {
@@ -34,7 +34,7 @@ app.addAdvanceHandler(async ({ metadata }) => {
             [value1, value2], // [!code focus]
             "0x", // [!code focus]
         ); // [!code focus]
-        await app.createVoucher(voucher);
+        app.createVoucher(voucher);
     }
     return "accept";
 });

--- a/apps/docs/pages/app/wallet/withdraw-batch-erc1155.mdx
+++ b/apps/docs/pages/app/wallet/withdraw-batch-erc1155.mdx
@@ -36,7 +36,7 @@ app.addAdvanceHandler(({ msgSender, appContract }) => {
         ); // [!code focus]
         app.createVoucher(voucher);
     }
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/withdraw-erc1155.mdx
+++ b/apps/docs/pages/app/wallet/withdraw-erc1155.mdx
@@ -28,7 +28,7 @@ app.addAdvanceHandler(({ msgSender, appContract }) => {
         const voucher = wallet.withdrawERC1155(dapp, token, user, 1n, value, "0x"); // [!code focus]
         app.createVoucher(voucher);
     }
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/withdraw-erc1155.mdx
+++ b/apps/docs/pages/app/wallet/withdraw-erc1155.mdx
@@ -20,13 +20,13 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0x04d724738873CB6a86328D2EbAEb2079D715e61e"; // ERC-1155 address
-app.addAdvanceHandler(async ({ metadata }) => {
-    const user = metadata.msgSender;
-    const dapp = metadata.appContract;
+app.addAdvanceHandler(({ msgSender, appContract }) => {
+    const user = msgSender;
+    const dapp = appContract;
     const value = wallet.erc1155BalanceOf(token, user, 1n);
     if (value > 0) {
         const voucher = wallet.withdrawERC1155(dapp, token, user, 1n, value, "0x"); // [!code focus]
-        await app.createVoucher(voucher);
+        app.createVoucher(voucher);
     }
     return "accept";
 });

--- a/apps/docs/pages/app/wallet/withdraw-erc20.mdx
+++ b/apps/docs/pages/app/wallet/withdraw-erc20.mdx
@@ -20,12 +20,12 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D"; // CTSI address
-app.addAdvanceHandler(async ({ metadata }) => {
-    const user = metadata.msgSender;
+app.addAdvanceHandler(({ msgSender }) => {
+    const user = msgSender;
     const value = wallet.erc20BalanceOf(token, user);
     if (value > 0) {
         const voucher = wallet.withdrawERC20(token, user, value); // [!code focus]
-        await app.createVoucher(voucher);
+        app.createVoucher(voucher);
     }
     return "accept";
 });

--- a/apps/docs/pages/app/wallet/withdraw-erc20.mdx
+++ b/apps/docs/pages/app/wallet/withdraw-erc20.mdx
@@ -27,7 +27,7 @@ app.addAdvanceHandler(({ msgSender }) => {
         const voucher = wallet.withdrawERC20(token, user, value); // [!code focus]
         app.createVoucher(voucher);
     }
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/withdraw-erc721.mdx
+++ b/apps/docs/pages/app/wallet/withdraw-erc721.mdx
@@ -28,7 +28,7 @@ app.addAdvanceHandler(({ msgSender, appContract }) => {
         const voucher = wallet.withdrawERC721(dapp, token, user, 1n); // [!code focus]
         app.createVoucher(voucher);
     }
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/docs/pages/app/wallet/withdraw-erc721.mdx
+++ b/apps/docs/pages/app/wallet/withdraw-erc721.mdx
@@ -20,13 +20,13 @@ const wallet = createWallet();
 app.addAdvanceHandler(wallet.handler);
 
 const token = "0xc6582A9b48F211Fa8c2B5b16CB615eC39bcA653B"; // NFT address
-app.addAdvanceHandler(async ({ metadata }) => {
-    const user = metadata.msgSender;
-    const dapp = metadata.appContract;
+app.addAdvanceHandler(({ msgSender, appContract }) => {
+    const user = msgSender;
+    const dapp = appContract;
     const hasOne = wallet.erc721Has(token, user, 1n);
     if (hasOne) {
         const voucher = wallet.withdrawERC721(dapp, token, user, 1n); // [!code focus]
-        await app.createVoucher(voucher);
+        app.createVoucher(voucher);
     }
     return "accept";
 });

--- a/apps/docs/pages/app/wallet/withdraw-ether.mdx
+++ b/apps/docs/pages/app/wallet/withdraw-ether.mdx
@@ -19,12 +19,12 @@ const wallet = createWallet();
 
 app.addAdvanceHandler(wallet.handler);
 
-app.addAdvanceHandler(async ({ metadata }) => {
-    const user = metadata.msgSender;
+app.addAdvanceHandler(({ msgSender }) => {
+    const user = msgSender;
     const value = wallet.etherBalanceOf(user);
     if (value > 0) {
         const voucher = wallet.withdrawEther(user, value); // [!code focus]
-        await app.createVoucher(voucher);
+        app.createVoucher(voucher);
     }
     return "accept";
 });

--- a/apps/docs/pages/app/wallet/withdraw-ether.mdx
+++ b/apps/docs/pages/app/wallet/withdraw-ether.mdx
@@ -26,7 +26,7 @@ app.addAdvanceHandler(({ msgSender }) => {
         const voucher = wallet.withdrawEther(user, value); // [!code focus]
         app.createVoucher(voucher);
     }
-    return "accept";
+    return true;
 });
 ```
 

--- a/apps/examples/src/abi.ts
+++ b/apps/examples/src/abi.ts
@@ -11,7 +11,7 @@ const abi = parseAbi([
 ]);
 
 // handle input encoded as ABI function call
-app.addAdvanceHandler(async ({ payload }) => {
+app.addAdvanceHandler(({ payload }) => {
     const { functionName, args } = decodeFunctionData({
         abi,
         data: toHex(payload),
@@ -29,6 +29,7 @@ app.addAdvanceHandler(async ({ payload }) => {
             return "accept";
         }
     }
+    return "reject";
 });
 
 // start app

--- a/apps/examples/src/abi.ts
+++ b/apps/examples/src/abi.ts
@@ -21,15 +21,15 @@ app.addAdvanceHandler(({ payload }) => {
         case "attackDragon": {
             const [dragonId, weapon] = args;
             console.log(`attacking dragon ${dragonId} with ${weapon}...`);
-            return "accept";
+            return true;
         }
 
         case "drinkPotion": {
             console.log(`drinking potion...`);
-            return "accept";
+            return true;
         }
     }
-    return "reject";
+    return false;
 });
 
 // start app

--- a/apps/examples/src/echo.ts
+++ b/apps/examples/src/echo.ts
@@ -4,14 +4,14 @@ import { createApp } from "@deroll/app";
 const app = createApp();
 
 // log incoming advance request
-app.addAdvanceHandler(async ({ payload }) => {
-    await app.createNotice({ payload });
+app.addAdvanceHandler(({ payload }) => {
+    app.createNotice(payload);
     return "accept";
 });
 
 // log incoming inspect request
-app.addInspectHandler(async ({ payload }) => {
-    await app.createReport({ payload });
+app.addInspectHandler(({ payload }) => {
+    app.createReport(payload);
 });
 
 // start app

--- a/apps/examples/src/echo.ts
+++ b/apps/examples/src/echo.ts
@@ -6,7 +6,7 @@ const app = createApp();
 // log incoming advance request
 app.addAdvanceHandler(({ payload }) => {
     app.createNotice(payload);
-    return "accept";
+    return true;
 });
 
 // log incoming inspect request

--- a/apps/examples/src/minimal.ts
+++ b/apps/examples/src/minimal.ts
@@ -9,7 +9,7 @@ app.addAdvanceHandler((request) => {
     const { type, payload, ...metadata } = request;
     console.log(metadata);
     console.log(payload.toString());
-    return "accept";
+    return true;
 });
 
 // log incoming inspect request

--- a/apps/examples/src/minimal.ts
+++ b/apps/examples/src/minimal.ts
@@ -5,15 +5,16 @@ import { toHex } from "viem";
 const app = createApp();
 
 // log incoming advance request
-app.addAdvanceHandler(async (data) => {
-    console.log(data.metadata);
-    console.log(data.payload.toString());
+app.addAdvanceHandler((request) => {
+    const { type, payload, ...metadata } = request;
+    console.log(metadata);
+    console.log(payload.toString());
     return "accept";
 });
 
 // log incoming inspect request
-app.addInspectHandler(async (data) => {
-    console.log(toHex(data.payload));
+app.addInspectHandler((request) => {
+    console.log(toHex(request.payload));
 });
 
 // start app

--- a/apps/examples/src/withdraw.ts
+++ b/apps/examples/src/withdraw.ts
@@ -9,7 +9,7 @@ const app = createApp();
 const abi = parseAbi(["function withdraw(address token, uint256 amount)"]);
 
 // handle input encoded as ABI function call
-app.addAdvanceHandler(async ({ metadata, payload }) => {
+app.addAdvanceHandler(({ msgSender, payload }) => {
     const { functionName, args } = decodeFunctionData({
         abi,
         data: toHex(payload),
@@ -18,20 +18,20 @@ app.addAdvanceHandler(async ({ metadata, payload }) => {
     switch (functionName) {
         case "withdraw": {
             const [token, amount] = args;
-            const recipient = metadata.msgSender;
 
             // encode voucher of token transfer to requester
             const voucher = createERC20TransferVoucher(
                 token,
-                recipient,
+                msgSender,
                 amount,
             );
 
             // create voucher output
-            await app.createVoucher(voucher);
+            app.createVoucher(voucher);
             return "accept";
         }
     }
+    return "reject";
 });
 
 // start app

--- a/apps/examples/src/withdraw.ts
+++ b/apps/examples/src/withdraw.ts
@@ -28,10 +28,10 @@ app.addAdvanceHandler(({ msgSender, payload }) => {
 
             // create voucher output
             app.createVoucher(voucher);
-            return "accept";
+            return true;
         }
     }
-    return "reject";
+    return false;
 });
 
 // start app

--- a/bun.lock
+++ b/bun.lock
@@ -123,11 +123,9 @@
     "packages/app/core": {
       "name": "@deroll/core",
       "version": "2.0.0-alpha.5",
-      "dependencies": {
-        "viem": "^2.55.13",
-      },
       "devDependencies": {
         "@biomejs/biome": "catalog:",
+        "@cartesi/rollup": "1.0.0-alpha.0",
         "@deroll/tsconfig": "workspace:*",
         "@types/node": "^26",
         "npm-run-all": "^4",
@@ -135,6 +133,9 @@
         "tsx": "^4",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
+      },
+      "peerDependencies": {
+        "@cartesi/rollup": "1.0.0-alpha.0",
       },
     },
     "packages/app/create-app": {

--- a/packages/app/app/src/app.ts
+++ b/packages/app/app/src/app.ts
@@ -74,29 +74,29 @@ export class NativeApp implements App {
     private handleAdvance = async (
         request: AdvanceRequest,
     ): Promise<RequestHandlerResult> => {
-        // initialize final result as reject, which is the case if no handler accepts the request
-        let finalResult: RequestHandlerResult = "reject";
+        // start out declined, which is the outcome if no handler accepts the request
+        let finalResult: RequestHandlerResult = false;
 
         // present the input to all handlers
         for (const handler of this.advanceHandlers) {
             try {
                 const result = await handler(request);
-                if (result === "accept") {
+                if (result) {
                     if (!this.options.broadcastAdvanceRequests) {
-                        // not broadcast, return accept immediately
+                        // not broadcast, accept immediately
                         return result;
                     }
 
                     // else, store the result, and return when all handlers have been called
                     finalResult = result;
                 }
-                // here result is "reject", just continue
+                // here the handler declined, just continue
             } catch (e) {
                 // a handler raised: the input is not processable, so reject the
                 // whole request rather than letting later handlers write state
                 // on top of a partially applied one
                 this.reportFailure(e);
-                return "reject";
+                return false;
             }
         }
         return finalResult;
@@ -111,10 +111,10 @@ export class NativeApp implements App {
                 await handler(request);
             } catch (e) {
                 this.reportFailure(e);
-                return "reject";
+                return false;
             }
         }
-        return "accept";
+        return true;
     };
 
     public addAdvanceHandler(handler: AdvanceRequestHandler): void {
@@ -129,14 +129,12 @@ export class NativeApp implements App {
         // set to true if there is a CMT_INPUTS env var defined
         const hostMode = !!process.env.CMT_INPUTS;
 
-        let status: RequestHandlerResult = "accept";
+        let status: RequestHandlerResult = true;
 
         // loop forever
         while (true) {
             try {
-                const request = this.rollup.finish({
-                    accept: status === "accept",
-                });
+                const request = this.rollup.finish({ accept: status });
                 switch (request.type) {
                     case "advance": {
                         status = await this.handleAdvance(request);

--- a/packages/app/app/src/app.ts
+++ b/packages/app/app/src/app.ts
@@ -1,14 +1,14 @@
 import { Rollup, RollupError } from "@cartesi/rollup";
 import { constants } from "node:os";
 import type {
+    AdvanceRequest,
     AdvanceRequestHandler,
     App,
     AppOptions,
+    BytesLike,
     DelegateCallVoucher,
-    Exception,
+    InspectRequest,
     InspectRequestHandler,
-    Notice,
-    Report,
     RequestHandlerResult,
     Voucher,
 } from "@deroll/core";
@@ -33,36 +33,54 @@ export class NativeApp implements App {
         this.rollup = new Rollup();
     }
 
-    public async createNotice(notice: Notice): Promise<bigint> {
-        return this.rollup.emitNotice(notice.payload);
+    public createNotice(payload: BytesLike): bigint {
+        return this.rollup.emitNotice(payload);
     }
 
-    public async createReport(report: Report): Promise<void> {
-        this.rollup.emitReport(report.payload);
+    public createReport(payload: BytesLike): void {
+        this.rollup.emitReport(payload);
     }
 
-    public async createVoucher(voucher: Voucher): Promise<bigint> {
+    public createVoucher(voucher: Voucher): bigint {
         return this.rollup.emitVoucher(voucher);
     }
 
-    public async createDelegateCallVoucher(
-        voucher: DelegateCallVoucher,
-    ): Promise<bigint> {
+    public createDelegateCallVoucher(voucher: DelegateCallVoucher): bigint {
         return this.rollup.emitDelegateCallVoucher(voucher);
     }
 
-    public async registerException(exception: Exception): Promise<void> {
-        this.rollup.emitException(exception.payload);
+    public registerException(payload: BytesLike): void {
+        this.rollup.emitException(payload);
     }
 
-    private handleAdvance: AdvanceRequestHandler = async (data) => {
+    /**
+     * A handler blew up, so the request could not be processed: report the
+     * failure and reject. Reports survive a rejection, so this is what makes
+     * the error observable from outside the machine — rather than only on
+     * stderr, inside a guest nobody is tailing.
+     */
+    private reportFailure(e: unknown): void {
+        console.error(e);
+        const message = e instanceof Error ? (e.stack ?? e.message) : String(e);
+        try {
+            this.rollup.emitReport(Buffer.from(message, "utf8"));
+        } catch (reportError) {
+            // emitting the report can itself fail (e.g. payload too large);
+            // never let that take down the request loop
+            console.error(reportError);
+        }
+    }
+
+    private handleAdvance = async (
+        request: AdvanceRequest,
+    ): Promise<RequestHandlerResult> => {
         // initialize final result as reject, which is the case if no handler accepts the request
         let finalResult: RequestHandlerResult = "reject";
 
         // present the input to all handlers
         for (const handler of this.advanceHandlers) {
             try {
-                const result = await handler(data);
+                const result = await handler(request);
                 if (result === "accept") {
                     if (!this.options.broadcastAdvanceRequests) {
                         // not broadcast, return accept immediately
@@ -74,23 +92,29 @@ export class NativeApp implements App {
                 }
                 // here result is "reject", just continue
             } catch (e) {
-                // one of the handlers raised an exception, just log it
-                // it will return "reject" if no handler accepts the request
-                console.error(e);
+                // a handler raised: the input is not processable, so reject the
+                // whole request rather than letting later handlers write state
+                // on top of a partially applied one
+                this.reportFailure(e);
+                return "reject";
             }
         }
         return finalResult;
     };
 
-    private handleInspect: InspectRequestHandler = async (data) => {
-        // present the input to all handlers
+    private handleInspect = async (
+        request: InspectRequest,
+    ): Promise<RequestHandlerResult> => {
+        // present the query to all handlers
         for (const handler of this.inspectHandlers) {
             try {
-                await handler(data);
+                await handler(request);
             } catch (e) {
-                console.error(e);
+                this.reportFailure(e);
+                return "reject";
             }
         }
+        return "accept";
     };
 
     public addAdvanceHandler(handler: AdvanceRequestHandler): void {
@@ -115,15 +139,11 @@ export class NativeApp implements App {
                 });
                 switch (request.type) {
                     case "advance": {
-                        const { payload, type, ...metadata } = request;
-                        status = await this.handleAdvance({
-                            metadata,
-                            payload,
-                        });
+                        status = await this.handleAdvance(request);
                         break;
                     }
                     case "inspect": {
-                        await this.handleInspect({ payload: request.payload });
+                        status = await this.handleInspect(request);
                         break;
                     }
                 }

--- a/packages/app/core/package.json
+++ b/packages/app/core/package.json
@@ -31,11 +31,12 @@
         "lint": "biome check",
         "prepack": "run-s build"
     },
-    "dependencies": {
-        "viem": "^2.55.13"
+    "peerDependencies": {
+        "@cartesi/rollup": "1.0.0-alpha.0"
     },
     "devDependencies": {
         "@biomejs/biome": "catalog:",
+        "@cartesi/rollup": "1.0.0-alpha.0",
         "@deroll/tsconfig": "workspace:*",
         "@types/node": "^26",
         "npm-run-all": "^4",

--- a/packages/app/core/src/index.ts
+++ b/packages/app/core/src/index.ts
@@ -1,24 +1,41 @@
 import type {
     AdvanceRequestHandler,
+    BytesLike,
     DelegateCallVoucher,
     InspectRequestHandler,
-    Notice,
-    Report,
     Voucher,
 } from "./types.js";
 
 export * from "./types.js";
 
 export type AppOptions = {
+    /**
+     * Present each advance request to every registered handler instead of
+     * stopping at the first one that accepts. The request is accepted if any
+     * handler accepted. Defaults to `false`.
+     */
     broadcastAdvanceRequests?: boolean;
 };
 
+/**
+ * The composition seam of deroll: a rollup loop that many independently
+ * authored handlers can plug into, plus the outputs those handlers emit.
+ *
+ * Output methods are synchronous, mirroring the binding — emitting an output
+ * is a device write, not I/O the event loop can interleave with.
+ */
 export interface App {
     start(): Promise<void>;
-    createNotice(request: Notice): Promise<bigint>;
-    createReport(request: Report): Promise<void>;
-    createVoucher(request: Voucher): Promise<bigint>;
-    createDelegateCallVoucher(request: DelegateCallVoucher): Promise<bigint>;
+    /** Emit a notice. Returns the output index. */
+    createNotice(payload: BytesLike): bigint;
+    /** Emit a report. Reports are not indexed, so nothing is returned. */
+    createReport(payload: BytesLike): void;
+    /** Emit a voucher. Returns the output index. */
+    createVoucher(voucher: Voucher): bigint;
+    /** Emit a delegate call voucher. Returns the output index. */
+    createDelegateCallVoucher(voucher: DelegateCallVoucher): bigint;
+    /** Signal that the request could not be processed, halting the machine. */
+    registerException(payload: BytesLike): void;
     addAdvanceHandler(handler: AdvanceRequestHandler): void;
     addInspectHandler(handler: InspectRequestHandler): void;
 }

--- a/packages/app/core/src/types.ts
+++ b/packages/app/core/src/types.ts
@@ -1,59 +1,39 @@
-import type { Address, Hex } from "viem";
+// The rollup protocol vocabulary — request shapes, output shapes and the byte
+// aliases — is owned by @cartesi/rollup, the libcmt binding. Deroll re-exports
+// it rather than restating it, so the two can never drift.
+export type {
+    AddressLike,
+    AdvanceRequest,
+    BytesLike,
+    DelegateCallVoucher,
+    Hex,
+    InspectRequest,
+    RollupRequest,
+    U256Like,
+    Voucher,
+} from "@cartesi/rollup";
 
-export type AdvanceRequestMetadata = {
-    chainId: bigint;
-    appContract: Address;
-    msgSender: Address;
-    blockNumber: bigint;
-    blockTimestamp: bigint;
-    prevRandao: bigint;
-    index: bigint;
-};
+import type { AdvanceRequest, InspectRequest } from "@cartesi/rollup";
 
-export type AdvanceRequestData = {
-    metadata: AdvanceRequestMetadata;
-    payload: Buffer;
-};
-
-export type InspectRequestData = {
-    payload: Buffer;
-};
-
-export type RollupAdvanceRequest = {
-    request_type: "advance_state";
-    data: AdvanceRequestData;
-};
-
-export type RollupInspectRequest = {
-    request_type: "inspect_state";
-    data: InspectRequestData;
-};
-export type RollupRequest = RollupAdvanceRequest | RollupInspectRequest;
-
-export type RequestType = RollupRequest["request_type"];
-export type RequestData = AdvanceRequestData | InspectRequestData;
-export type RequestMetadata = AdvanceRequestMetadata;
+/**
+ * Verdict an advance handler returns for an input. On `"reject"` the machine
+ * state is reverted and any notices/vouchers emitted for the input are
+ * discarded; reports survive.
+ */
 export type RequestHandlerResult = "accept" | "reject";
-export type Payload = Hex | Uint8Array;
-export type Notice = { payload: Payload };
-export type Report = { payload: Payload };
-export type Voucher = {
-    destination: Address;
-    value?: bigint;
-    payload?: Hex;
-};
-export type DelegateCallVoucher = {
-    destination: Address;
-    payload?: Hex;
-};
-export type Exception = { payload: Payload };
 
-export type NoticeResponse = { index: bigint };
-export type ReportResponse = Record<string, never>; // XXX: should probably be 204 (no content)
-export type VoucherResponse = { index: bigint };
-
-export type InspectRequestHandler = (data: InspectRequestData) => Promise<void>;
-
+/**
+ * Handles an advance (state-changing) request. May be synchronous — the
+ * underlying binding is, since `finish` pauses the whole guest.
+ */
 export type AdvanceRequestHandler = (
-    data: AdvanceRequestData,
-) => Promise<RequestHandlerResult>;
+    request: AdvanceRequest,
+) => RequestHandlerResult | Promise<RequestHandlerResult>;
+
+/**
+ * Handles an inspect (read-only) request. Produces reports; it cannot change
+ * state, so it returns no verdict.
+ */
+export type InspectRequestHandler = (
+    request: InspectRequest,
+) => void | Promise<void>;

--- a/packages/app/core/src/types.ts
+++ b/packages/app/core/src/types.ts
@@ -16,11 +16,19 @@ export type {
 import type { AdvanceRequest, InspectRequest } from "@cartesi/rollup";
 
 /**
- * Verdict an advance handler returns for an input. On `"reject"` the machine
- * state is reverted and any notices/vouchers emitted for the input are
- * discarded; reports survive.
+ * Whether an advance handler handled the input: `true` accepts it, `false`
+ * declines and passes it to the next handler.
+ *
+ * Note that a single `false` does not reject the input — only an input no
+ * handler accepted is rejected, which reverts the machine state and discards
+ * the notices and vouchers emitted for it (reports survive).
+ *
+ * There is deliberately no `void` in this type. `Rollup.run` in the binding
+ * accepts a request unless a handler returns `false`; deroll is the opposite,
+ * rejecting unless a handler opts in, so a handler that falls off its end must
+ * be a type error rather than a silent accept.
  */
-export type RequestHandlerResult = "accept" | "reject";
+export type RequestHandlerResult = boolean;
 
 /**
  * Handles an advance (state-changing) request. May be synchronous — the

--- a/packages/app/router/__tests__/index.test.ts
+++ b/packages/app/router/__tests__/index.test.ts
@@ -1,9 +1,15 @@
-import type { App } from "@deroll/core";
+import type { App, InspectRequest } from "@deroll/core";
 import { stringToHex } from "viem";
 import { beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { mock, mockClear } from "vitest-mock-extended";
 
 import { type Handler, type Router, createRouter } from "../src/index.js";
+
+// build a libcmt-shaped inspect request from a query string
+const inspect = (url: string): InspectRequest => ({
+    type: "inspect",
+    payload: Buffer.from(url, "utf8"),
+});
 
 describe("Router", () => {
     let app: App;
@@ -18,41 +24,33 @@ describe("Router", () => {
         router = createRouter({ app });
     });
 
-    test("no routes", async () => {
-        await router.handler({ payload: stringToHex("test") });
+    test("no routes", () => {
+        router.handler(inspect("test"));
         expect(app.createReport).toHaveBeenCalledTimes(0);
     });
 
-    test("simple route", async () => {
+    test("simple route", () => {
         router.add("ping", (_a, _b) => "pong");
-        await router.handler({ payload: stringToHex("ping") });
-        expect(app.createReport).toHaveBeenCalledWith({
-            payload: stringToHex("pong"),
-        });
+        router.handler(inspect("ping"));
+        expect(app.createReport).toHaveBeenCalledWith(stringToHex("pong"));
     });
 
-    test("single param", async () => {
+    test("single param", () => {
         router.add("tests/:id", () => "pong");
-        await router.handler({ payload: stringToHex("tests/123") });
-        expect(app.createReport).toHaveBeenCalledWith({
-            payload: stringToHex("pong"),
-        });
+        router.handler(inspect("tests/123"));
+        expect(app.createReport).toHaveBeenCalledWith(stringToHex("pong"));
     });
 
-    test("two params", async () => {
+    test("two params", () => {
         router.add("tests/:id/second/:name", () => "pong");
-        await router.handler({ payload: stringToHex("tests/123/second/cool") });
-        expect(app.createReport).toHaveBeenCalledWith({
-            payload: stringToHex("pong"),
-        });
+        router.handler(inspect("tests/123/second/cool"));
+        expect(app.createReport).toHaveBeenCalledWith(stringToHex("pong"));
     });
 
-    test("typed params", async () => {
+    test("typed params", () => {
         const handler: Handler<{ id: string }> = (a, _b) => a.params.id;
         router.add("tests/:id", handler);
-        await router.handler({ payload: stringToHex("tests/123") });
-        expect(app.createReport).toHaveBeenCalledWith({
-            payload: stringToHex("123"),
-        });
+        router.handler(inspect("tests/123"));
+        expect(app.createReport).toHaveBeenCalledWith(stringToHex("123"));
     });
 });

--- a/packages/app/router/src/index.ts
+++ b/packages/app/router/src/index.ts
@@ -1,11 +1,11 @@
-import type { App, InspectRequestData } from "@deroll/core";
+import type { App, InspectRequest } from "@deroll/core";
 import {
     type MatchFunction,
     type MatchResult,
     type Path,
     match,
 } from "path-to-regexp";
-import { bytesToString, stringToBytes, toBytes, toHex } from "viem";
+import { bytesToString, stringToHex } from "viem";
 
 export type Handler<P extends object = object> = (
     match: MatchResult<P>,
@@ -56,14 +56,12 @@ export class Router {
         return undefined;
     }
 
-    public async handler(data: InspectRequestData): Promise<void> {
-        const url = bytesToString(toBytes(data.payload));
+    public handler(request: InspectRequest): void {
+        const url = bytesToString(request.payload);
         const result = this.handle(url);
         if (result) {
             // create single report with handler result
-            await this.options.app.createReport({
-                payload: toHex(stringToBytes(result)),
-            });
+            this.options.app.createReport(stringToHex(result));
         }
     }
 }

--- a/packages/app/wallet/__tests__/deposit.test.ts
+++ b/packages/app/wallet/__tests__/deposit.test.ts
@@ -42,7 +42,7 @@ describe("deposit", () => {
         const response = await wallet.handler(
             advance(etherPortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.etherBalanceOf(sender)).toEqual(value);
     });
 
@@ -58,7 +58,7 @@ describe("deposit", () => {
         const response = await wallet.handler(
             advance(etherPortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.etherBalanceOf(sender.toLowerCase())).toEqual(value);
     });
 
@@ -77,7 +77,7 @@ describe("deposit", () => {
         const response = await wallet.handler(
             advance(erc20PortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc20BalanceOf(token, sender)).toBe(value);
     });
 
@@ -97,7 +97,7 @@ describe("deposit", () => {
         const response = await wallet.handler(
             advance(erc721PortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc721Has(token, sender, tokenId)).toBe(true);
     });
 
@@ -119,7 +119,7 @@ describe("deposit", () => {
         const response = await wallet.handler(
             advance(erc1155SinglePortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc1155BalanceOf(token, sender, tokenId)).toBe(value);
     });
 
@@ -142,7 +142,7 @@ describe("deposit", () => {
         const response = await wallet.handler(
             advance(erc1155BatchPortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc1155BalanceOf(token, sender, tokenIds[0])).toBe(
             values[0],
         );

--- a/packages/app/wallet/__tests__/deposit.test.ts
+++ b/packages/app/wallet/__tests__/deposit.test.ts
@@ -10,23 +10,22 @@ import {
     erc1155SinglePortalAddress,
     etherPortalAddress,
 } from "@cartesi/codec";
-import type { AdvanceRequestData } from "@deroll/core";
+import type { AdvanceRequest } from "@deroll/core";
 import type { Address, Hex } from "viem";
 import { describe, expect, test } from "vitest";
 
 import { createWallet } from "../src/index.js";
 
 // build a libcmt-shaped advance request from the portal sender and a hex payload
-const advance = (msgSender: Hex, payload: Hex): AdvanceRequestData => ({
-    metadata: {
-        chainId: 1n,
-        appContract: "0xab7528bb862fB57E8A2BCd567a2e929a0Be56a5e",
-        msgSender,
-        blockNumber: 0n,
-        blockTimestamp: 0n,
-        prevRandao: 0n,
-        index: 0n,
-    },
+const advance = (msgSender: Hex, payload: Hex): AdvanceRequest => ({
+    type: "advance",
+    chainId: 1n,
+    appContract: "0xab7528bb862fB57E8A2BCd567a2e929a0Be56a5e",
+    msgSender,
+    blockNumber: 0n,
+    blockTimestamp: 0n,
+    prevRandao: 0n,
+    index: 0n,
     payload: Buffer.from(payload.slice(2), "hex"),
 });
 

--- a/packages/app/wallet/__tests__/noop.test.ts
+++ b/packages/app/wallet/__tests__/noop.test.ts
@@ -29,6 +29,6 @@ describe("noop", () => {
             index: 0n,
             payload: Buffer.from("deadbeef", "hex"),
         });
-        expect(response).toBe("reject");
+        expect(response).toBe(false);
     });
 });

--- a/packages/app/wallet/__tests__/noop.test.ts
+++ b/packages/app/wallet/__tests__/noop.test.ts
@@ -19,15 +19,14 @@ describe("noop", () => {
     test("reject", async () => {
         const wallet = createWallet();
         const response = await wallet.handler({
-            metadata: {
-                chainId: 1n,
-                appContract: "0xab7528bb862fB57E8A2BCd567a2e929a0Be56a5e",
-                msgSender: "0x18930e8a66a1DbE21D00581216789AAB7460Afd0",
-                blockNumber: 0n,
-                blockTimestamp: 0n,
-                prevRandao: 0n,
-                index: 0n,
-            },
+            type: "advance",
+            chainId: 1n,
+            appContract: "0xab7528bb862fB57E8A2BCd567a2e929a0Be56a5e",
+            msgSender: "0x18930e8a66a1DbE21D00581216789AAB7460Afd0",
+            blockNumber: 0n,
+            blockTimestamp: 0n,
+            prevRandao: 0n,
+            index: 0n,
             payload: Buffer.from("deadbeef", "hex"),
         });
         expect(response).toBe("reject");

--- a/packages/app/wallet/__tests__/transfer.test.ts
+++ b/packages/app/wallet/__tests__/transfer.test.ts
@@ -10,23 +10,22 @@ import {
     erc1155SinglePortalAddress,
     etherPortalAddress,
 } from "@cartesi/codec";
-import type { AdvanceRequestData } from "@deroll/core";
+import type { AdvanceRequest } from "@deroll/core";
 import type { Hex } from "viem";
 import { describe, expect, test } from "vitest";
 
 import { createWallet } from "../src/index.js";
 
 // build a libcmt-shaped advance request from the portal sender and a hex payload
-const advance = (msgSender: Hex, payload: Hex): AdvanceRequestData => ({
-    metadata: {
-        chainId: 1n,
-        appContract: "0xab7528bb862fB57E8A2BCd567a2e929a0Be56a5e",
-        msgSender,
-        blockNumber: 0n,
-        blockTimestamp: 0n,
-        prevRandao: 0n,
-        index: 0n,
-    },
+const advance = (msgSender: Hex, payload: Hex): AdvanceRequest => ({
+    type: "advance",
+    chainId: 1n,
+    appContract: "0xab7528bb862fB57E8A2BCd567a2e929a0Be56a5e",
+    msgSender,
+    blockNumber: 0n,
+    blockTimestamp: 0n,
+    prevRandao: 0n,
+    index: 0n,
     payload: Buffer.from(payload.slice(2), "hex"),
 });
 

--- a/packages/app/wallet/__tests__/transfer.test.ts
+++ b/packages/app/wallet/__tests__/transfer.test.ts
@@ -54,7 +54,7 @@ describe("transfer", () => {
         const response = await wallet.handler(
             advance(etherPortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.etherBalanceOf(from)).toEqual(value);
         expect(wallet.etherBalanceOf(to)).toEqual(0n);
 
@@ -90,7 +90,7 @@ describe("transfer", () => {
         const response = await wallet.handler(
             advance(erc20PortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc20BalanceOf(token, from)).toEqual(value);
         expect(wallet.erc20BalanceOf(token, to)).toEqual(0n);
 
@@ -129,7 +129,7 @@ describe("transfer", () => {
         const response = await wallet.handler(
             advance(erc721PortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc721Has(token, from, tokenId)).toEqual(true);
         expect(wallet.erc721Has(token, to, tokenId)).toEqual(false);
 
@@ -171,7 +171,7 @@ describe("transfer", () => {
         const response = await wallet.handler(
             advance(erc1155SinglePortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc1155BalanceOf(token, from, tokenId)).toEqual(value);
         expect(wallet.erc1155BalanceOf(token, to, tokenId)).toEqual(0n);
 
@@ -229,7 +229,7 @@ describe("transfer", () => {
         const response = await wallet.handler(
             advance(erc1155BatchPortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc1155BalanceOf(token, from, tokenIds[0])).toEqual(
             values[0],
         );

--- a/packages/app/wallet/__tests__/withdraw.test.ts
+++ b/packages/app/wallet/__tests__/withdraw.test.ts
@@ -59,7 +59,7 @@ describe("withdraw", () => {
         const response = await wallet.handler(
             advance(etherPortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.etherBalanceOf(sender)).toEqual(value);
 
         const voucher = wallet.withdrawEther(sender, withdraw);
@@ -92,7 +92,7 @@ describe("withdraw", () => {
         const response = await wallet.handler(
             advance(erc20PortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc20BalanceOf(token, sender)).toBe(value);
 
         const voucher = wallet.withdrawERC20(token, sender, withdraw);
@@ -135,7 +135,7 @@ describe("withdraw", () => {
         const response = await wallet.handler(
             advance(erc721PortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc721Has(token, sender, tokenId)).toBe(true);
 
         const voucher = wallet.withdrawERC721(dapp, token, sender, tokenId);
@@ -184,7 +184,7 @@ describe("withdraw", () => {
         const response = await wallet.handler(
             advance(erc1155SinglePortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc1155BalanceOf(token, sender, tokenId)).toBe(value);
 
         const voucher = wallet.withdrawERC1155(
@@ -272,7 +272,7 @@ describe("withdraw", () => {
         const response = await wallet.handler(
             advance(erc1155BatchPortalAddress, payload),
         );
-        expect(response).toBeTruthy();
+        expect(response).toBe(true);
         expect(wallet.erc1155BalanceOf(token, sender, tokenIds[0])).toBe(
             values[0],
         );

--- a/packages/app/wallet/__tests__/withdraw.test.ts
+++ b/packages/app/wallet/__tests__/withdraw.test.ts
@@ -10,7 +10,7 @@ import {
     erc1155SinglePortalAddress,
     etherPortalAddress,
 } from "@cartesi/codec";
-import type { AdvanceRequestData } from "@deroll/core";
+import type { AdvanceRequest } from "@deroll/core";
 import {
     type Hex,
     encodeFunctionData,
@@ -24,16 +24,15 @@ import { erc1155Abi } from "../src/abi/index.js";
 import { createWallet } from "../src/index.js";
 
 // build a libcmt-shaped advance request from the portal sender and a hex payload
-const advance = (msgSender: Hex, payload: Hex): AdvanceRequestData => ({
-    metadata: {
-        chainId: 1n,
-        appContract: "0xab7528bb862fB57E8A2BCd567a2e929a0Be56a5e",
-        msgSender,
-        blockNumber: 0n,
-        blockTimestamp: 0n,
-        prevRandao: 0n,
-        index: 0n,
-    },
+const advance = (msgSender: Hex, payload: Hex): AdvanceRequest => ({
+    type: "advance",
+    chainId: 1n,
+    appContract: "0xab7528bb862fB57E8A2BCd567a2e929a0Be56a5e",
+    msgSender,
+    blockNumber: 0n,
+    blockTimestamp: 0n,
+    prevRandao: 0n,
+    index: 0n,
     payload: Buffer.from(payload.slice(2), "hex"),
 });
 

--- a/packages/app/wallet/src/wallet.ts
+++ b/packages/app/wallet/src/wallet.ts
@@ -157,11 +157,11 @@ export class WalletAppImpl implements WalletApp {
         return wallet;
     }
 
-    public handler: AdvanceRequestHandler = async (data) => {
+    public handler: AdvanceRequestHandler = (request) => {
         // decode payload as a portal deposit, dispatching on msgSender
         const deposit = decodeDeposit({
-            msgSender: data.metadata.msgSender,
-            payload: data.payload,
+            msgSender: request.msgSender,
+            payload: request.payload,
         });
 
         switch (deposit?.type) {

--- a/packages/app/wallet/src/wallet.ts
+++ b/packages/app/wallet/src/wallet.ts
@@ -175,7 +175,7 @@ export class WalletAppImpl implements WalletApp {
                 wallet.ether += value;
 
                 this.wallets[sender] = wallet;
-                return "accept";
+                return true;
             }
             case "Erc20Deposit": {
                 const { token, sender, value } = deposit;
@@ -189,7 +189,7 @@ export class WalletAppImpl implements WalletApp {
                     : value;
 
                 this.wallets[sender] = wallet;
-                return "accept";
+                return true;
             }
             case "Erc721Deposit": {
                 const { sender, token, tokenId } = deposit;
@@ -202,7 +202,7 @@ export class WalletAppImpl implements WalletApp {
                 wallet.erc721[token].add(tokenId);
 
                 this.wallets[sender] = wallet;
-                return "accept";
+                return true;
             }
             case "Erc1155SingleDeposit": {
                 const { sender, token, tokenId, value } = deposit;
@@ -218,7 +218,7 @@ export class WalletAppImpl implements WalletApp {
                 );
 
                 this.wallets[sender] = wallet;
-                return "accept";
+                return true;
             }
             case "Erc1155BatchDeposit": {
                 const { sender, token, tokenIds, values } = deposit;
@@ -236,10 +236,10 @@ export class WalletAppImpl implements WalletApp {
                 });
 
                 this.wallets[sender] = wallet;
-                return "accept";
+                return true;
             }
         }
-        return "reject";
+        return false;
     };
 
     public transferEther(from: string, to: string, value: bigint): void {


### PR DESCRIPTION
## Why

This started as an evaluation of whether `@deroll/core` and `@deroll/app` still earn their place now that `@cartesi/rollup` exists — it already ships a `Rollup.run({ advance, inspect })` loop, and the two deroll packages are only ~230 lines combined.

The conclusion was **keep both, but stop them restating the protocol**:

- **`@deroll/app` earns its place** on multi-handler composition. `Rollup.run()` takes exactly *one* advance handler and *one* inspect handler; `addAdvanceHandler`/`addInspectHandler` are what let `wallet.handler` and `router.handler` be independently authored libraries sharing one loop. It also inverts the accept default (reject unless a handler opts in, which is the safer default for a rollup) and converts host-mode `ENODATA` into a clean exit.
- **`@deroll/core` earns its place** as the composition seam — wallet and router depend on the `App` interface, not on the concrete app.
- **What did *not* earn its place** was the vocabulary. Nine of ~22 exported types had zero consumers outside `core/src` — `request_type: "advance_state"`, nested `data`, `NoticeResponse = { index }`, `ReportResponse = Record<string, never>` (still carrying its `// XXX: should probably be 204` comment) — all leftovers of the removed Rollup HTTP Server transport. The surviving types were near-duplicates of the binding's, but narrower and drifting.

## What changed

**Protocol types come from `@cartesi/rollup`.** `@deroll/core` re-exports `AdvanceRequest`, `InspectRequest`, `RollupRequest`, `Voucher`, `DelegateCallVoucher`, `BytesLike`, `AddressLike`, `U256Like` and `Hex` instead of declaring its own copies, so the two cannot drift. `viem` is no longer a dependency of `core` at all. `core/src/types.ts` is now mostly doc comments.

**Dead types deleted:** `RollupAdvanceRequest`, `RollupInspectRequest`, `RequestType`, `RequestData`, `RequestMetadata`, `NoticeResponse`, `ReportResponse`, `VoucherResponse`.

**The advance request is flat.** `AdvanceRequestData`/`AdvanceRequestMetadata` → `AdvanceRequest`, which also removes the destructuring conversion in the request loop.

```diff
-app.addAdvanceHandler(async ({ metadata, payload }) => {
-    console.log(metadata.msgSender);
+app.addAdvanceHandler(({ msgSender, payload }) => {
+    console.log(msgSender);
     return "accept";
 });
```

**Outputs are synchronous, and notice/report payloads are no longer wrapped.** Emitting an output is a device write, not I/O the event loop can interleave with — `finish` pauses the entire guest. Vouchers keep their object argument, since they carry a `destination` and optional `value` besides the payload.

```diff
-const id = await app.createNotice({ payload: stringToHex("hello") });
-await app.createReport({ payload: stringToHex("hello") });
+const id = app.createNotice(stringToHex("hello"));
+app.createReport(stringToHex("hello"));
```

Handlers may still be `async` — they are awaited — but no longer have to be. The wallet and router handlers are now synchronous.

**A handler exception rejects the request and is reported.** Previously it went to `stderr` and the next handler ran anyway, which could let a later handler write state on top of a partially applied one, and left the failure invisible from outside the machine. Now the input is rejected immediately, remaining handlers are skipped, and the error is emitted as a report — which survives the rejection.

**`registerException` is now on the `App` interface.** `NativeApp` always implemented it, but it was missing from the interface `createApp` returns, so it was unreachable through the public API.

**Bonus fix:** `Router.handler` was doing `bytesToString(toBytes(buffer))`, which only round-tripped correctly because `TextEncoder` coerces a `Buffer` via `toString()`. It now reads the `Buffer` directly.

## Two judgment calls worth reviewing

**`@cartesi/rollup` is a non-optional `peerDependency` of `@deroll/core`.** This weakens the "no native addon in the pure packages" property — wallet and router now get the tarball in their tree. I chose it anyway because the binding is a **singleton native resource** (`new Rollup()` returns `-EBUSY` if one is already open), so two copies at different versions in one tree is a real failure mode; a non-optional peer forces exactly one hoisted copy. What survives is "the addon is never *loaded* by the pure packages," which is what matters for their tests. An optional peer would have preserved the stronger claim but broken type resolution when absent.

**The `Notice`/`Report`/`Exception` wrapper types are gone.** This is a larger API break than just dropping `async`. Easy to revert to `createNotice({ payload })` if preferred.

## Verification

- `bun run build` — 9/9 packages, including `@deroll/docs`, whose Vocs/twoslash snippets are genuinely typechecked. All 33 affected `.mdx` pages updated, plus the migration guide.
- `bun run lint` clean; `tsc --noEmit` on `apps/examples` clean.
- 35 tests pass (30 wallet, 5 router).
- **End-to-end against the real native binding + libcmt mock:** `minimal` prints the flat request and exits 0; `echo` emits a correct `Notice(bytes)` output (`c258d6e5` selector, `advance-0\n` payload); a throwing handler produced a report file with the stack, **no** output files, and the second handler never ran — the new error policy confirmed at runtime, not just in types.

`bun run test` at the repo root still fails on `@deroll/genext2fs`, whose addon needs a C toolchain the dev container lacks. Pre-existing and unrelated to this change; it aborts the turbo run, which is why wallet/router were run directly.

A changeset (`minor` for core/app/router/wallet) documents each break with diffs, and `CLAUDE.md` is updated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ud9jF1bYpLMhJaJU8q1KDX)_