### PR TITLE
Update App documentation card packages list

### DIFF
--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -15,7 +15,7 @@ import { HomePage } from 'vocs'
   <a className="home-card" href="/app/quick-start">
     <h3>App</h3>
     <p>Build Cartesi application backends in TypeScript — handle inputs, manage assets, and emit outputs.</p>
-    <span className="home-card-packages"><code>@deroll/app</code>, <code>@deroll/wallet</code></span>
+    <span className="home-card-packages"><code>@deroll/wallet</code>, <code>@deroll/router</code></span>
   </a>
   <a className="home-card" href="/genext2fs">
     <h3>Bindings</h3>


### PR DESCRIPTION
## Summary
Updated the packages listed on the App documentation card to reflect the current recommended packages for building Cartesi application backends.

## Changes
- Replaced `@deroll/app` with `@deroll/router` in the App card package list
- Kept `@deroll/wallet` as the first package in the list

## Details
The documentation card on the homepage now displays `@deroll/wallet` and `@deroll/router` as the key packages for building Cartesi application backends, removing the reference to `@deroll/app`.

https://claude.ai/code/session_01JjkiJdQADnw6Qf5Qhbppji